### PR TITLE
fix: override titles for Cloudflare-blocked blog posts and add Medium thumbnail

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -140,14 +140,18 @@ external_sources:
     posts:
       - url: https://blog.x.com/engineering/en_us/topics/insights/2021/temporal-graph-networks
         published_date: 2021-01-25
+        title: "Deep Learning on Dynamic Graphs"
         thumbnail: /assets/img/publication_preview/tgn.png
       - url: https://blog.x.com/engineering/en_us/topics/insights/2022/graph-machine-learning-with-missing-node-features
         published_date: 2022-03-17
+        title: "Graph Machine Learning with Missing Node Features"
         thumbnail: /assets/img/publication_preview/fp.gif
   - name: Medium
     posts:
       - url: https://medium.com/data-science/simple-scalable-graph-neural-networks-7eb04f366d07
         published_date: 2020-08-08
+        title: "Simple Scalable Graph Neural Networks"
+        thumbnail: /assets/img/publication_preview/sign.png
   - name: GraphCore Blog
     posts:
       - url: https://www.graphcore.ai/posts/accelerating-and-scaling-temporal-graph-networks-on-the-graphcore-ipu

--- a/_plugins/external-posts.rb
+++ b/_plugins/external-posts.rb
@@ -87,6 +87,7 @@ module ExternalPosts
         content = fetch_content_from_url(post['url'])
         content[:published] = parse_published_date(post['published_date'])
         content[:thumbnail] = post['thumbnail'] if post.key?('thumbnail')
+        content[:title] = post['title'] if post.key?('title')
         create_document(site, src['name'], post['url'], content, src)
       end
     end


### PR DESCRIPTION
## Summary

- Adds `title` override support to `_plugins/external-posts.rb` (mirrors existing `thumbnail` override pattern) so per-post `title:` values in `_config.yml` bypass HTTP-fetched titles
- Sets explicit `title:` for the three external posts whose Cloudflare bot detection returns "Just a moment..." permanently in the blog listing (two Twitter/X Engineering Blog posts, one Medium post)
- Adds `thumbnail: /assets/img/publication_preview/sign.png` for the Medium post

## Test plan

- [x] Run `docker compose up --build`
- [x] Visit `http://localhost:8080/blog/` and confirm the three previously broken posts show real titles instead of "Just a moment..."
- [x] Confirm the Medium post (Aug 2020) shows the sign.png thumbnail
- [x] Confirm the two Twitter posts still show tgn.png and fp.gif thumbnails

🤖 Generated with [Claude Code](https://claude.com/claude-code)