### PR TITLE
feat: redesign outreach page layout

### DIFF
--- a/_pages/outreach.md
+++ b/_pages/outreach.md
@@ -20,18 +20,27 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
     <tbody>
       <tr>
         <td class="text-nowrap" style="width:5rem"><small class="text-muted">Nov 22</small></td>
-        <td><em>A Primer on Graph Neural Networks</em><br><small><a href="https://www.upf.edu/web/colt" target="_blank" rel="noopener noreferrer">COLT Seminar</a>, University of Pompeu Fabra, Barcelona</small></td>
-        <td><a href="../assets/pdf/gnn_primer.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a></td>
+        <td>
+          <em>A Primer on Graph Neural Networks</em><br>
+          <small><a href="https://www.upf.edu/web/colt" target="_blank" rel="noopener noreferrer">COLT Seminar</a>, University of Pompeu Fabra, Barcelona</small><br>
+          <a href="../assets/pdf/gnn_primer.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a>
+        </td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Sep 14</small></td>
-        <td><em>Edge Directionality Improves Learning on Heterophilic Graphs</em><br><small><a href="https://www.cs.mcgill.ca/~shuang43/rg.html" target="_blank" rel="noopener noreferrer">Temporal Graph Reading Group</a></small></td>
-        <td><a href="../assets/pdf/dirgnn_tgl_reading_group.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a> <a href="https://www.youtube.com/watch?v=VjpUSR1NZvI" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a></td>
+        <td>
+          <em>Edge Directionality Improves Learning on Heterophilic Graphs</em><br>
+          <small><a href="https://www.cs.mcgill.ca/~shuang43/rg.html" target="_blank" rel="noopener noreferrer">Temporal Graph Reading Group</a></small><br>
+          <a href="../assets/pdf/dirgnn_tgl_reading_group.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a>
+          <a href="https://www.youtube.com/watch?v=VjpUSR1NZvI" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a>
+        </td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Sep 07</small></td>
-        <td><em>Edge Directionality Improves Learning on Heterophilic Graphs</em><br><small><a href="https://www.gain-group.de/html/events.html" target="_blank" rel="noopener noreferrer">Explainability and Applicability of GNNs Workshop</a>, Kassel</small></td>
-        <td></td>
+        <td>
+          <em>Edge Directionality Improves Learning on Heterophilic Graphs</em><br>
+          <small><a href="https://www.gain-group.de/html/events.html" target="_blank" rel="noopener noreferrer">Explainability and Applicability of GNNs Workshop</a>, Kassel</small>
+        </td>
       </tr>
     </tbody>
   </table>
@@ -44,23 +53,34 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
     <tbody>
       <tr>
         <td class="text-nowrap" style="width:5rem"><small class="text-muted">Sep 28</small></td>
-        <td><em>Improving Machine Learning at Twitter using Graphs</em><br><small><a href="https://privacyweek.it/" target="_blank" rel="noopener noreferrer">Privacy Week</a></small></td>
-        <td><a href="https://privacyweek.it/event/potenziare-lapprendimento-automatico-su-twitter-utilizzando-i-grafi/" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video <small class="text-muted">it</small></a></td>
+        <td>
+          <em>Improving Machine Learning at Twitter using Graphs</em><br>
+          <small><a href="https://privacyweek.it/" target="_blank" rel="noopener noreferrer">Privacy Week</a></small><br>
+          <a href="https://privacyweek.it/event/potenziare-lapprendimento-automatico-su-twitter-utilizzando-i-grafi/" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video <small class="text-muted">it</small></a>
+        </td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Sep 09</small></td>
-        <td><em>Learning on Graphs with Missing Node Features</em><br><small><a href="https://www.tigergraph.com/" target="_blank" rel="noopener noreferrer">TigerGraph</a> Reading Group</small></td>
-        <td></td>
+        <td>
+          <em>Learning on Graphs with Missing Node Features</em><br>
+          <small><a href="https://www.tigergraph.com/" target="_blank" rel="noopener noreferrer">TigerGraph</a> Reading Group</small>
+        </td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Mar 01</small></td>
-        <td><em>Learning on Graphs with Missing Node Features</em><br><small><a href="https://portal.valencelabs.com/logg" target="_blank" rel="noopener noreferrer">Learning on Graphs and Geometry Reading Group</a></small></td>
-        <td><a href="https://docs.google.com/presentation/d/11dAeJRalTI7K1YAxMNz_yElZ0lVO5Bw7n0LBqSd-OUY/edit#slide=id.g1017b3d77ca_0_0" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Slides</a> <a href="https://www.youtube.com/watch?v=xe5A-xQTBdM" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a></td>
+        <td>
+          <em>Learning on Graphs with Missing Node Features</em><br>
+          <small><a href="https://portal.valencelabs.com/logg" target="_blank" rel="noopener noreferrer">Learning on Graphs and Geometry Reading Group</a></small><br>
+          <a href="https://docs.google.com/presentation/d/11dAeJRalTI7K1YAxMNz_yElZ0lVO5Bw7n0LBqSd-OUY/edit#slide=id.g1017b3d77ca_0_0" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Slides</a>
+          <a href="https://www.youtube.com/watch?v=xe5A-xQTBdM" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a>
+        </td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Feb 24</small></td>
-        <td><em>Learning on Graphs with Missing Node Features</em><br><small><a href="https://www.robots.ox.ac.uk/~parg/" target="_blank" rel="noopener noreferrer">Machine Learning Research Group</a>, University of Oxford</small></td>
-        <td></td>
+        <td>
+          <em>Learning on Graphs with Missing Node Features</em><br>
+          <small><a href="https://www.robots.ox.ac.uk/~parg/" target="_blank" rel="noopener noreferrer">Machine Learning Research Group</a>, University of Oxford</small>
+        </td>
       </tr>
     </tbody>
   </table>
@@ -73,33 +93,47 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
     <tbody>
       <tr>
         <td class="text-nowrap" style="width:5rem"><small class="text-muted">Nov 23</small></td>
-        <td><em>Learning on Graphs with Missing Node Features</em><br><small>University of Cambridge <a href="http://talks.cam.ac.uk/talk/index/165859" target="_blank" rel="noopener noreferrer">AI Research Group Talks</a></small></td>
-        <td></td>
+        <td>
+          <em>Learning on Graphs with Missing Node Features</em><br>
+          <small>University of Cambridge <a href="http://talks.cam.ac.uk/talk/index/165859" target="_blank" rel="noopener noreferrer">AI Research Group Talks</a></small>
+        </td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Nov 17</small></td>
-        <td><em>Graph Neural Networks with Almost No Features</em><br><small><a href="https://www.torontomachinelearning.com/" target="_blank" rel="noopener noreferrer">Toronto Machine Learning Summit</a></small></td>
-        <td></td>
+        <td>
+          <em>Graph Neural Networks with Almost No Features</em><br>
+          <small><a href="https://www.torontomachinelearning.com/" target="_blank" rel="noopener noreferrer">Toronto Machine Learning Summit</a></small>
+        </td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Jun 16</small></td>
-        <td><em>Machine Learning on Dynamic Graphs: Temporal Graph Networks</em><br><small><a href="https://mlopsworld.com/" target="_blank" rel="noopener noreferrer">MLOps World 2021</a></small></td>
-        <td></td>
+        <td>
+          <em>Machine Learning on Dynamic Graphs: Temporal Graph Networks</em><br>
+          <small><a href="https://mlopsworld.com/" target="_blank" rel="noopener noreferrer">MLOps World 2021</a></small>
+        </td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Apr 26</small></td>
-        <td><em>Machine Learning on Dynamic Graphs: Temporal Graph Networks</em><br><small>Intel ML Seminar</small></td>
-        <td><a href="../assets/pdf/intel_tgn.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a></td>
+        <td>
+          <em>Machine Learning on Dynamic Graphs: Temporal Graph Networks</em><br>
+          <small>Intel ML Seminar</small><br>
+          <a href="../assets/pdf/intel_tgn.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a>
+        </td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Apr 09</small></td>
-        <td><em>Machine Learning on Dynamic Graphs: Temporal Graph Networks</em><br><small><a href="https://gnnsys.github.io/" target="_blank" rel="noopener noreferrer">GNNSys'21 Workshop</a></small></td>
-        <td></td>
+        <td>
+          <em>Machine Learning on Dynamic Graphs: Temporal Graph Networks</em><br>
+          <small><a href="https://gnnsys.github.io/" target="_blank" rel="noopener noreferrer">GNNSys'21 Workshop</a></small>
+        </td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Jan 22</small></td>
-        <td><em>Dynamic Graphs and Temporal Graph Networks</em><br><small>University of Liverpool <a href="https://seminars.csc.liv.ac.uk/abstract.php?id=979" target="_blank" rel="noopener noreferrer">Networks and Distributed Computing Series</a></small></td>
-        <td><a href="../assets/pdf/TGN_2021_01_22.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a></td>
+        <td>
+          <em>Dynamic Graphs and Temporal Graph Networks</em><br>
+          <small>University of Liverpool <a href="https://seminars.csc.liv.ac.uk/abstract.php?id=979" target="_blank" rel="noopener noreferrer">Networks and Distributed Computing Series</a></small><br>
+          <a href="../assets/pdf/TGN_2021_01_22.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a>
+        </td>
       </tr>
     </tbody>
   </table>
@@ -112,8 +146,12 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
     <tbody>
       <tr>
         <td class="text-nowrap" style="width:5rem"><small class="text-muted">Jul 21</small></td>
-        <td><em>TGN: Temporal Graph Networks</em><br><small><a href="https://ai.science/" target="_blank" rel="noopener noreferrer">AISC</a></small></td>
-        <td><a href="../assets/pdf/tgn_aisc_2020.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a> <a href="https://www.youtube.com/watch?v=W1GvX2ZcUmY" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a></td>
+        <td>
+          <em>TGN: Temporal Graph Networks</em><br>
+          <small><a href="https://ai.science/" target="_blank" rel="noopener noreferrer">AISC</a></small><br>
+          <a href="../assets/pdf/tgn_aisc_2020.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a>
+          <a href="https://www.youtube.com/watch?v=W1GvX2ZcUmY" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a>
+        </td>
       </tr>
     </tbody>
   </table>
@@ -126,13 +164,19 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
     <tbody>
       <tr>
         <td class="text-nowrap" style="width:5rem"><small class="text-muted">2021/03/02</small></td>
-        <td><em>Scaling Graph Neural Networks to Twitter-scale</em><br><small>with <a href="https://www.youtube.com/channel/UCxw9_WYmLqlj5PyXu2AWU_g" target="_blank" rel="noopener noreferrer">Zak Jost</a></small></td>
-        <td><a href="https://www.youtube.com/watch?v=ZSMEXchR3w8" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a></td>
+        <td>
+          <em>Scaling Graph Neural Networks to Twitter-scale</em><br>
+          <small>with <a href="https://www.youtube.com/channel/UCxw9_WYmLqlj5PyXu2AWU_g" target="_blank" rel="noopener noreferrer">Zak Jost</a></small><br>
+          <a href="https://www.youtube.com/watch?v=ZSMEXchR3w8" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a>
+        </td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">2021/01/14</small></td>
-        <td><em>My journey, my research at Twitter and Imperial College, and my work at LeadTheFuture</em><br><small>with <a href="https://italia-podcast.it/podcast/smarter-podcast" target="_blank" rel="noopener noreferrer">The Smarter Podcast</a></small></td>
-        <td><a href="https://www.youtube.com/watch?v=x4CeQ3S_DCA" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video <small class="text-muted">it</small></a></td>
+        <td>
+          <em>My journey, my research at Twitter and Imperial College, and my work at LeadTheFuture</em><br>
+          <small>with <a href="https://italia-podcast.it/podcast/smarter-podcast" target="_blank" rel="noopener noreferrer">The Smarter Podcast</a></small><br>
+          <a href="https://www.youtube.com/watch?v=x4CeQ3S_DCA" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video <small class="text-muted">it</small></a>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/_pages/outreach.md
+++ b/_pages/outreach.md
@@ -202,21 +202,54 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
 
 <h2 class="category">Workshop Involvement</h2>
 
-#### Organized
-
-- **2023/12**: [Temporal Graph Learning Workshop @ NeurIPS 2023](https://sites.google.com/view/tglworkshop-2023/home)
-
-#### Panel Participation
-
-- **2022/12**: [Temporal Graph Learning Workshop @ NeurIPS 2022](https://sites.google.com/view/tglworkshop2022/home#h.q1t0lweplm6e)
-
-#### Program Committee
-
-- **2022/12**: [NeurReps Workshop – Symmetry and Geometry in Neural Representations](https://www.neurreps.org/) (at NeurIPS 2022)
-- **2022/02**: [GCLR 22 – 2nd Workshop on Graphs and more complex structures for learning and reasoning](https://sites.google.com/view/gclr2022/home?authuser=0) (at AAAI 2022)
-- **2021/10**: [GReS – Workshop on Graph Neural Networks for Recommendation and Search](https://europe.naverlabs.com/gres-workshop/) (at ACM RecSys 2021)
-- **2021/04**: [GNNSys'21 -- Workshop on Graph Neural Networks and Systems](https://gnnsys.github.io/) (at MLSys 2021)
-- **2021/02**: [AAAI-21 GCLR](https://sites.google.com/view/gclr2021/home) (at AAAI 2021)
+<div class="table-responsive">
+  <table class="table table-sm table-borderless">
+    <tbody>
+      <tr>
+        <td class="text-nowrap" style="width:5rem"><small class="text-muted">2023/12</small></td>
+        <td><a href="https://sites.google.com/view/tglworkshop-2023/home" target="_blank" rel="noopener noreferrer">Temporal Graph Learning Workshop</a></td>
+        <td class="text-nowrap"><small class="text-muted">NeurIPS 2023</small></td>
+        <td class="text-nowrap"><small class="text-muted">Organizer</small></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">2022/12</small></td>
+        <td><a href="https://sites.google.com/view/tglworkshop2022/home#h.q1t0lweplm6e" target="_blank" rel="noopener noreferrer">Temporal Graph Learning Workshop</a></td>
+        <td class="text-nowrap"><small class="text-muted">NeurIPS 2022</small></td>
+        <td class="text-nowrap"><small class="text-muted">Panel</small></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">2022/12</small></td>
+        <td><a href="https://www.neurreps.org/" target="_blank" rel="noopener noreferrer">NeurReps Workshop – Symmetry and Geometry in Neural Representations</a></td>
+        <td class="text-nowrap"><small class="text-muted">NeurIPS 2022</small></td>
+        <td class="text-nowrap"><small class="text-muted">PC Member</small></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">2022/02</small></td>
+        <td><a href="https://sites.google.com/view/gclr2022/home?authuser=0" target="_blank" rel="noopener noreferrer">GCLR 22 – 2nd Workshop on Graphs and more complex structures for learning and reasoning</a></td>
+        <td class="text-nowrap"><small class="text-muted">AAAI 2022</small></td>
+        <td class="text-nowrap"><small class="text-muted">PC Member</small></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">2021/10</small></td>
+        <td><a href="https://europe.naverlabs.com/gres-workshop/" target="_blank" rel="noopener noreferrer">GReS – Workshop on Graph Neural Networks for Recommendation and Search</a></td>
+        <td class="text-nowrap"><small class="text-muted">ACM RecSys 2021</small></td>
+        <td class="text-nowrap"><small class="text-muted">PC Member</small></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">2021/04</small></td>
+        <td><a href="https://gnnsys.github.io/" target="_blank" rel="noopener noreferrer">GNNSys'21 – Workshop on Graph Neural Networks and Systems</a></td>
+        <td class="text-nowrap"><small class="text-muted">MLSys 2021</small></td>
+        <td class="text-nowrap"><small class="text-muted">PC Member</small></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">2021/02</small></td>
+        <td><a href="https://sites.google.com/view/gclr2021/home" target="_blank" rel="noopener noreferrer">AAAI-21 GCLR</a></td>
+        <td class="text-nowrap"><small class="text-muted">AAAI 2021</small></td>
+        <td class="text-nowrap"><small class="text-muted">PC Member</small></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 <h2 class="category">Supervision and Mentoring</h2>
 

--- a/_pages/outreach.md
+++ b/_pages/outreach.md
@@ -21,12 +21,12 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
       <tr>
         <td class="text-nowrap" style="width:5rem"><small class="text-muted">Nov 22</small></td>
         <td><em>A Primer on Graph Neural Networks</em><br><small><a href="https://www.upf.edu/web/colt" target="_blank" rel="noopener noreferrer">COLT Seminar</a>, University of Pompeu Fabra, Barcelona</small></td>
-        <td class="text-nowrap"><small><a href="../assets/pdf/gnn_primer.pdf">[Slides]</a></small></td>
+        <td><a href="../assets/pdf/gnn_primer.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a></td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Sep 14</small></td>
         <td><em>Edge Directionality Improves Learning on Heterophilic Graphs</em><br><small><a href="https://www.cs.mcgill.ca/~shuang43/rg.html" target="_blank" rel="noopener noreferrer">Temporal Graph Reading Group</a></small></td>
-        <td class="text-nowrap"><small><a href="../assets/pdf/dirgnn_tgl_reading_group.pdf">[Slides]</a>&nbsp;<a href="https://www.youtube.com/watch?v=VjpUSR1NZvI" target="_blank" rel="noopener noreferrer">[Video]</a></small></td>
+        <td><a href="../assets/pdf/dirgnn_tgl_reading_group.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a> <a href="https://www.youtube.com/watch?v=VjpUSR1NZvI" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a></td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Sep 07</small></td>
@@ -45,7 +45,7 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
       <tr>
         <td class="text-nowrap" style="width:5rem"><small class="text-muted">Sep 28</small></td>
         <td><em>Improving Machine Learning at Twitter using Graphs</em><br><small><a href="https://privacyweek.it/" target="_blank" rel="noopener noreferrer">Privacy Week</a></small></td>
-        <td class="text-nowrap"><small><a href="https://privacyweek.it/event/potenziare-lapprendimento-automatico-su-twitter-utilizzando-i-grafi/" target="_blank" rel="noopener noreferrer">[Video]</a> <span class="text-muted">(it)</span></small></td>
+        <td><a href="https://privacyweek.it/event/potenziare-lapprendimento-automatico-su-twitter-utilizzando-i-grafi/" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video <small class="text-muted">it</small></a></td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Sep 09</small></td>
@@ -55,7 +55,7 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
       <tr>
         <td class="text-nowrap"><small class="text-muted">Mar 01</small></td>
         <td><em>Learning on Graphs with Missing Node Features</em><br><small><a href="https://portal.valencelabs.com/logg" target="_blank" rel="noopener noreferrer">Learning on Graphs and Geometry Reading Group</a></small></td>
-        <td class="text-nowrap"><small><a href="https://docs.google.com/presentation/d/11dAeJRalTI7K1YAxMNz_yElZ0lVO5Bw7n0LBqSd-OUY/edit#slide=id.g1017b3d77ca_0_0" target="_blank" rel="noopener noreferrer">[Slides]</a>&nbsp;<a href="https://www.youtube.com/watch?v=xe5A-xQTBdM" target="_blank" rel="noopener noreferrer">[Video]</a></small></td>
+        <td><a href="https://docs.google.com/presentation/d/11dAeJRalTI7K1YAxMNz_yElZ0lVO5Bw7n0LBqSd-OUY/edit#slide=id.g1017b3d77ca_0_0" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Slides</a> <a href="https://www.youtube.com/watch?v=xe5A-xQTBdM" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a></td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Feb 24</small></td>
@@ -89,7 +89,7 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
       <tr>
         <td class="text-nowrap"><small class="text-muted">Apr 26</small></td>
         <td><em>Machine Learning on Dynamic Graphs: Temporal Graph Networks</em><br><small>Intel ML Seminar</small></td>
-        <td class="text-nowrap"><small><a href="../assets/pdf/intel_tgn.pdf">[Slides]</a></small></td>
+        <td><a href="../assets/pdf/intel_tgn.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a></td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Apr 09</small></td>
@@ -99,7 +99,7 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
       <tr>
         <td class="text-nowrap"><small class="text-muted">Jan 22</small></td>
         <td><em>Dynamic Graphs and Temporal Graph Networks</em><br><small>University of Liverpool <a href="https://seminars.csc.liv.ac.uk/abstract.php?id=979" target="_blank" rel="noopener noreferrer">Networks and Distributed Computing Series</a></small></td>
-        <td class="text-nowrap"><small><a href="../assets/pdf/TGN_2021_01_22.pdf">[Slides]</a></small></td>
+        <td><a href="../assets/pdf/TGN_2021_01_22.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a></td>
       </tr>
     </tbody>
   </table>
@@ -113,7 +113,7 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
       <tr>
         <td class="text-nowrap" style="width:5rem"><small class="text-muted">Jul 21</small></td>
         <td><em>TGN: Temporal Graph Networks</em><br><small><a href="https://ai.science/" target="_blank" rel="noopener noreferrer">AISC</a></small></td>
-        <td class="text-nowrap"><small><a href="../assets/pdf/tgn_aisc_2020.pdf">[Slides]</a>&nbsp;<a href="https://www.youtube.com/watch?v=W1GvX2ZcUmY" target="_blank" rel="noopener noreferrer">[Video]</a></small></td>
+        <td><a href="../assets/pdf/tgn_aisc_2020.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a> <a href="https://www.youtube.com/watch?v=W1GvX2ZcUmY" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a></td>
       </tr>
     </tbody>
   </table>
@@ -127,12 +127,12 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
       <tr>
         <td class="text-nowrap" style="width:5rem"><small class="text-muted">2021/03/02</small></td>
         <td><em>Scaling Graph Neural Networks to Twitter-scale</em><br><small>with <a href="https://www.youtube.com/channel/UCxw9_WYmLqlj5PyXu2AWU_g" target="_blank" rel="noopener noreferrer">Zak Jost</a></small></td>
-        <td class="text-nowrap"><small><a href="https://www.youtube.com/watch?v=ZSMEXchR3w8" target="_blank" rel="noopener noreferrer">[Video]</a></small></td>
+        <td><a href="https://www.youtube.com/watch?v=ZSMEXchR3w8" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a></td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">2021/01/14</small></td>
         <td><em>My journey, my research at Twitter and Imperial College, and my work at LeadTheFuture</em><br><small>with <a href="https://italia-podcast.it/podcast/smarter-podcast" target="_blank" rel="noopener noreferrer">The Smarter Podcast</a></small></td>
-        <td class="text-nowrap"><small><a href="https://www.youtube.com/watch?v=x4CeQ3S_DCA" target="_blank" rel="noopener noreferrer">[Video]</a> <span class="text-muted">(it)</span></small></td>
+        <td><a href="https://www.youtube.com/watch?v=x4CeQ3S_DCA" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video <small class="text-muted">it</small></a></td>
       </tr>
     </tbody>
   </table>

--- a/_pages/outreach.md
+++ b/_pages/outreach.md
@@ -9,47 +9,136 @@ nav_order: 4
 
 <!-- pages/outreach.md -->
 
-## Talks
+<h2 class="category">Talks</h2>
 
-#### 2023
+Invited talks and presentations at academic seminars, workshops, and industry events.
 
-- **2023/11/22**: "_A Primer on Graph Neural Networks_" at the [COLT Seminar](https://www.upf.edu/web/colt), University of Pompeu Fabra, Barcelona [[Slides](../assets/pdf/gnn_primer.pdf)]
-- **2023/09/14**: "_Edge Directionality Improves Learning on Heterophilic Graphs_" at the [Temporal Graph Reading Group
-  ](https://www.cs.mcgill.ca/~shuang43/rg.html) [[Slides](../assets/pdf/dirgnn_tgl_reading_group.pdf)][[Video](https://www.youtube.com/watch?v=VjpUSR1NZvI)]
-- **2023/09/07**: "_Edge Directionality Improves Learning on Heterophilic Graphs_" at the [Explainability and Applicability of Graph Neural Networks Workshop
-  ](https://www.gain-group.de/html/events.html) in Kassel
+<h3 class="year">2023</h3>
 
-#### 2022
+<div class="table-responsive">
+  <table class="table table-sm table-borderless">
+    <tbody>
+      <tr>
+        <td class="text-nowrap" style="width:5rem"><small class="text-muted">Nov 22</small></td>
+        <td><em>A Primer on Graph Neural Networks</em><br><small><a href="https://www.upf.edu/web/colt" target="_blank" rel="noopener noreferrer">COLT Seminar</a>, University of Pompeu Fabra, Barcelona</small></td>
+        <td class="text-nowrap"><small><a href="../assets/pdf/gnn_primer.pdf">[Slides]</a></small></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">Sep 14</small></td>
+        <td><em>Edge Directionality Improves Learning on Heterophilic Graphs</em><br><small><a href="https://www.cs.mcgill.ca/~shuang43/rg.html" target="_blank" rel="noopener noreferrer">Temporal Graph Reading Group</a></small></td>
+        <td class="text-nowrap"><small><a href="../assets/pdf/dirgnn_tgl_reading_group.pdf">[Slides]</a>&nbsp;<a href="https://www.youtube.com/watch?v=VjpUSR1NZvI" target="_blank" rel="noopener noreferrer">[Video]</a></small></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">Sep 07</small></td>
+        <td><em>Edge Directionality Improves Learning on Heterophilic Graphs</em><br><small><a href="https://www.gain-group.de/html/events.html" target="_blank" rel="noopener noreferrer">Explainability and Applicability of GNNs Workshop</a>, Kassel</small></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
-- **2022/09/28**: "_Improving Machine Learning at Twitter using Graphs_" at [Privacy Week](https://privacyweek.it/) [[Video](https://privacyweek.it/event/potenziare-lapprendimento-automatico-su-twitter-utilizzando-i-grafi/) (in Italian)]
-- **2022/09/09**: "_Learning on Graphs with Missing Node Features_" at the [Tiger Graph](https://www.tigergraph.com/) Reading Group
-- **2022/03/01**: "_Learning on Graphs with Missing Node Features_" at the [Learning on Graphs and Geometry Reading Group](https://portal.valencelabs.com/logg) [[Slides](https://docs.google.com/presentation/d/11dAeJRalTI7K1YAxMNz_yElZ0lVO5Bw7n0LBqSd-OUY/edit#slide=id.g1017b3d77ca_0_0)][[Video](https://www.youtube.com/watch?v=xe5A-xQTBdM)]
-- **2022/02/24**: "_Learning on Graphs with Missing Node Features_" at the [Machine Learning Research Group](https://www.robots.ox.ac.uk/~parg/)
-  of the University of Oxford
+<h3 class="year">2022</h3>
 
-#### 2021
+<div class="table-responsive">
+  <table class="table table-sm table-borderless">
+    <tbody>
+      <tr>
+        <td class="text-nowrap" style="width:5rem"><small class="text-muted">Sep 28</small></td>
+        <td><em>Improving Machine Learning at Twitter using Graphs</em><br><small><a href="https://privacyweek.it/" target="_blank" rel="noopener noreferrer">Privacy Week</a></small></td>
+        <td class="text-nowrap"><small><a href="https://privacyweek.it/event/potenziare-lapprendimento-automatico-su-twitter-utilizzando-i-grafi/" target="_blank" rel="noopener noreferrer">[Video]</a> <span class="text-muted">(it)</span></small></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">Sep 09</small></td>
+        <td><em>Learning on Graphs with Missing Node Features</em><br><small><a href="https://www.tigergraph.com/" target="_blank" rel="noopener noreferrer">TigerGraph</a> Reading Group</small></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">Mar 01</small></td>
+        <td><em>Learning on Graphs with Missing Node Features</em><br><small><a href="https://portal.valencelabs.com/logg" target="_blank" rel="noopener noreferrer">Learning on Graphs and Geometry Reading Group</a></small></td>
+        <td class="text-nowrap"><small><a href="https://docs.google.com/presentation/d/11dAeJRalTI7K1YAxMNz_yElZ0lVO5Bw7n0LBqSd-OUY/edit#slide=id.g1017b3d77ca_0_0" target="_blank" rel="noopener noreferrer">[Slides]</a>&nbsp;<a href="https://www.youtube.com/watch?v=xe5A-xQTBdM" target="_blank" rel="noopener noreferrer">[Video]</a></small></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">Feb 24</small></td>
+        <td><em>Learning on Graphs with Missing Node Features</em><br><small><a href="https://www.robots.ox.ac.uk/~parg/" target="_blank" rel="noopener noreferrer">Machine Learning Research Group</a>, University of Oxford</small></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
-- **2021/11/23**: "_Learning on Graphs with Missing Node Features_" at University of Cambridge [AI Research Group Talks](http://talks.cam.ac.uk/talk/index/165859)
-- **2021/11/17**: "_Graph Neural Networks with Almost No Features_" at the [Toronto Machine Learning Summit](https://www.torontomachinelearning.com/)
-- **2021/06/16**: "_Machine Learning on Dynamic Graphs: Temporal Graph Networks_" at [MLOps World 2021](https://mlopsworld.com/)
-- **2021/04/26**: "_Machine Learning on Dynamic Graphs: Temporal Graph Networks_" at Intel ML Seminar [[Slides](../assets/pdf/intel_tgn.pdf)]
-- **2021/04/09**: "_Machine Learning on Dynamic Graphs: Temporal Graph Networks_" at the [GNNSys'21](https://gnnsys.github.io/) workshop
-- **2021/01/22**: "_Dynamic Graphs and Temporal Graph Networks_" at the University of Liverpool [Networks and Distributed Computing Series](https://seminars.csc.liv.ac.uk/abstract.php?id=979) [[Slides](../assets/pdf/TGN_2021_01_22.pdf)]
+<h3 class="year">2021</h3>
 
-#### 2020
+<div class="table-responsive">
+  <table class="table table-sm table-borderless">
+    <tbody>
+      <tr>
+        <td class="text-nowrap" style="width:5rem"><small class="text-muted">Nov 23</small></td>
+        <td><em>Learning on Graphs with Missing Node Features</em><br><small>University of Cambridge <a href="http://talks.cam.ac.uk/talk/index/165859" target="_blank" rel="noopener noreferrer">AI Research Group Talks</a></small></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">Nov 17</small></td>
+        <td><em>Graph Neural Networks with Almost No Features</em><br><small><a href="https://www.torontomachinelearning.com/" target="_blank" rel="noopener noreferrer">Toronto Machine Learning Summit</a></small></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">Jun 16</small></td>
+        <td><em>Machine Learning on Dynamic Graphs: Temporal Graph Networks</em><br><small><a href="https://mlopsworld.com/" target="_blank" rel="noopener noreferrer">MLOps World 2021</a></small></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">Apr 26</small></td>
+        <td><em>Machine Learning on Dynamic Graphs: Temporal Graph Networks</em><br><small>Intel ML Seminar</small></td>
+        <td class="text-nowrap"><small><a href="../assets/pdf/intel_tgn.pdf">[Slides]</a></small></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">Apr 09</small></td>
+        <td><em>Machine Learning on Dynamic Graphs: Temporal Graph Networks</em><br><small><a href="https://gnnsys.github.io/" target="_blank" rel="noopener noreferrer">GNNSys'21 Workshop</a></small></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">Jan 22</small></td>
+        <td><em>Dynamic Graphs and Temporal Graph Networks</em><br><small>University of Liverpool <a href="https://seminars.csc.liv.ac.uk/abstract.php?id=979" target="_blank" rel="noopener noreferrer">Networks and Distributed Computing Series</a></small></td>
+        <td class="text-nowrap"><small><a href="../assets/pdf/TGN_2021_01_22.pdf">[Slides]</a></small></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
-- **2020/07/21**: "_TGN: Temporal Graph Networks_" at [AISC](https://ai.science/) [[Slides](../assets/pdf/tgn_aisc_2020.pdf)][[Video](https://www.youtube.com/watch?v=W1GvX2ZcUmY)]
+<h3 class="year">2020</h3>
 
----
+<div class="table-responsive">
+  <table class="table table-sm table-borderless">
+    <tbody>
+      <tr>
+        <td class="text-nowrap" style="width:5rem"><small class="text-muted">Jul 21</small></td>
+        <td><em>TGN: Temporal Graph Networks</em><br><small><a href="https://ai.science/" target="_blank" rel="noopener noreferrer">AISC</a></small></td>
+        <td class="text-nowrap"><small><a href="../assets/pdf/tgn_aisc_2020.pdf">[Slides]</a>&nbsp;<a href="https://www.youtube.com/watch?v=W1GvX2ZcUmY" target="_blank" rel="noopener noreferrer">[Video]</a></small></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
-## Conversations
+<h2 class="category">Conversations</h2>
 
-- **2021/03/02**: "_Scaling Graph Neural Networks to Twitter-scale_" with [Zak Jost](https://www.youtube.com/channel/UCxw9_WYmLqlj5PyXu2AWU_g) [[Video](https://www.youtube.com/watch?v=ZSMEXchR3w8)]
-- **2021/01/14**: "_My journey, my research at Twitter and Imperial College, and my work at LeadTheFuture_" with [The Smarter Podcast](https://italia-podcast.it/podcast/smarter-podcast) [[Video](https://www.youtube.com/watch?v=x4CeQ3S_DCA) (in Italian)]
+<div class="table-responsive">
+  <table class="table table-sm table-borderless">
+    <tbody>
+      <tr>
+        <td class="text-nowrap" style="width:5rem"><small class="text-muted">2021/03/02</small></td>
+        <td><em>Scaling Graph Neural Networks to Twitter-scale</em><br><small>with <a href="https://www.youtube.com/channel/UCxw9_WYmLqlj5PyXu2AWU_g" target="_blank" rel="noopener noreferrer">Zak Jost</a></small></td>
+        <td class="text-nowrap"><small><a href="https://www.youtube.com/watch?v=ZSMEXchR3w8" target="_blank" rel="noopener noreferrer">[Video]</a></small></td>
+      </tr>
+      <tr>
+        <td class="text-nowrap"><small class="text-muted">2021/01/14</small></td>
+        <td><em>My journey, my research at Twitter and Imperial College, and my work at LeadTheFuture</em><br><small>with <a href="https://italia-podcast.it/podcast/smarter-podcast" target="_blank" rel="noopener noreferrer">The Smarter Podcast</a></small></td>
+        <td class="text-nowrap"><small><a href="https://www.youtube.com/watch?v=x4CeQ3S_DCA" target="_blank" rel="noopener noreferrer">[Video]</a> <span class="text-muted">(it)</span></small></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
----
-
-## Workshop Involvement
+<h2 class="category">Workshop Involvement</h2>
 
 #### Organized
 
@@ -61,15 +150,13 @@ nav_order: 4
 
 #### Program Committee
 
-- **2022/12**: [NeurReps Workshop – Symmetry and Geometry in Neural Representations](https://www.neurreps.org/) (at Neurips 2022)
+- **2022/12**: [NeurReps Workshop – Symmetry and Geometry in Neural Representations](https://www.neurreps.org/) (at NeurIPS 2022)
 - **2022/02**: [GCLR 22 – 2nd Workshop on Graphs and more complex structures for learning and reasoning](https://sites.google.com/view/gclr2022/home?authuser=0) (at AAAI 2022)
 - **2021/10**: [GReS – Workshop on Graph Neural Networks for Recommendation and Search](https://europe.naverlabs.com/gres-workshop/) (at ACM RecSys 2021)
 - **2021/04**: [GNNSys'21 -- Workshop on Graph Neural Networks and Systems](https://gnnsys.github.io/) (at MLSys 2021)
 - **2021/02**: [AAAI-21 GCLR](https://sites.google.com/view/gclr2021/home) (at AAAI 2021)
 
----
-
-## Supervision and Mentoring
+<h2 class="category">Supervision and Mentoring</h2>
 
 Mentoring bright and motivated students is one of the most rewarding aspects of my research. I am grateful for their creativity and curiosity, and for how much I learn from them in return.
 

--- a/_pages/outreach.md
+++ b/_pages/outreach.md
@@ -22,17 +22,21 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
         <td class="text-nowrap" style="width:5rem"><small class="text-muted">Nov 22</small></td>
         <td>
           <em>A Primer on Graph Neural Networks</em><br>
-          <small><a href="https://www.upf.edu/web/colt" target="_blank" rel="noopener noreferrer">COLT Seminar</a>, University of Pompeu Fabra, Barcelona</small><br>
-          <a href="../assets/pdf/gnn_primer.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a>
+          <small><a href="https://www.upf.edu/web/colt" target="_blank" rel="noopener noreferrer">COLT Seminar</a>, University of Pompeu Fabra, Barcelona</small>
+          <div class="links">
+            <a href="../assets/pdf/gnn_primer.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a>
+          </div>
         </td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">Sep 14</small></td>
         <td>
           <em>Edge Directionality Improves Learning on Heterophilic Graphs</em><br>
-          <small><a href="https://www.cs.mcgill.ca/~shuang43/rg.html" target="_blank" rel="noopener noreferrer">Temporal Graph Reading Group</a></small><br>
-          <a href="../assets/pdf/dirgnn_tgl_reading_group.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a>
-          <a href="https://www.youtube.com/watch?v=VjpUSR1NZvI" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a>
+          <small><a href="https://www.cs.mcgill.ca/~shuang43/rg.html" target="_blank" rel="noopener noreferrer">Temporal Graph Reading Group</a></small>
+          <div class="links">
+            <a href="../assets/pdf/dirgnn_tgl_reading_group.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a>
+            <a href="https://www.youtube.com/watch?v=VjpUSR1NZvI" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a>
+          </div>
         </td>
       </tr>
       <tr>
@@ -55,8 +59,10 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
         <td class="text-nowrap" style="width:5rem"><small class="text-muted">Sep 28</small></td>
         <td>
           <em>Improving Machine Learning at Twitter using Graphs</em><br>
-          <small><a href="https://privacyweek.it/" target="_blank" rel="noopener noreferrer">Privacy Week</a></small><br>
-          <a href="https://privacyweek.it/event/potenziare-lapprendimento-automatico-su-twitter-utilizzando-i-grafi/" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video <small class="text-muted">it</small></a>
+          <small><a href="https://privacyweek.it/" target="_blank" rel="noopener noreferrer">Privacy Week</a></small>
+          <div class="links">
+            <a href="https://privacyweek.it/event/potenziare-lapprendimento-automatico-su-twitter-utilizzando-i-grafi/" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video <small class="text-muted">it</small></a>
+          </div>
         </td>
       </tr>
       <tr>
@@ -70,9 +76,11 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
         <td class="text-nowrap"><small class="text-muted">Mar 01</small></td>
         <td>
           <em>Learning on Graphs with Missing Node Features</em><br>
-          <small><a href="https://portal.valencelabs.com/logg" target="_blank" rel="noopener noreferrer">Learning on Graphs and Geometry Reading Group</a></small><br>
-          <a href="https://docs.google.com/presentation/d/11dAeJRalTI7K1YAxMNz_yElZ0lVO5Bw7n0LBqSd-OUY/edit#slide=id.g1017b3d77ca_0_0" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Slides</a>
-          <a href="https://www.youtube.com/watch?v=xe5A-xQTBdM" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a>
+          <small><a href="https://portal.valencelabs.com/logg" target="_blank" rel="noopener noreferrer">Learning on Graphs and Geometry Reading Group</a></small>
+          <div class="links">
+            <a href="https://docs.google.com/presentation/d/11dAeJRalTI7K1YAxMNz_yElZ0lVO5Bw7n0LBqSd-OUY/edit#slide=id.g1017b3d77ca_0_0" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Slides</a>
+            <a href="https://www.youtube.com/watch?v=xe5A-xQTBdM" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a>
+          </div>
         </td>
       </tr>
       <tr>
@@ -116,8 +124,10 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
         <td class="text-nowrap"><small class="text-muted">Apr 26</small></td>
         <td>
           <em>Machine Learning on Dynamic Graphs: Temporal Graph Networks</em><br>
-          <small>Intel ML Seminar</small><br>
-          <a href="../assets/pdf/intel_tgn.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a>
+          <small>Intel ML Seminar</small>
+          <div class="links">
+            <a href="../assets/pdf/intel_tgn.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a>
+          </div>
         </td>
       </tr>
       <tr>
@@ -131,8 +141,10 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
         <td class="text-nowrap"><small class="text-muted">Jan 22</small></td>
         <td>
           <em>Dynamic Graphs and Temporal Graph Networks</em><br>
-          <small>University of Liverpool <a href="https://seminars.csc.liv.ac.uk/abstract.php?id=979" target="_blank" rel="noopener noreferrer">Networks and Distributed Computing Series</a></small><br>
-          <a href="../assets/pdf/TGN_2021_01_22.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a>
+          <small>University of Liverpool <a href="https://seminars.csc.liv.ac.uk/abstract.php?id=979" target="_blank" rel="noopener noreferrer">Networks and Distributed Computing Series</a></small>
+          <div class="links">
+            <a href="../assets/pdf/TGN_2021_01_22.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a>
+          </div>
         </td>
       </tr>
     </tbody>
@@ -148,9 +160,11 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
         <td class="text-nowrap" style="width:5rem"><small class="text-muted">Jul 21</small></td>
         <td>
           <em>TGN: Temporal Graph Networks</em><br>
-          <small><a href="https://ai.science/" target="_blank" rel="noopener noreferrer">AISC</a></small><br>
-          <a href="../assets/pdf/tgn_aisc_2020.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a>
-          <a href="https://www.youtube.com/watch?v=W1GvX2ZcUmY" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a>
+          <small><a href="https://ai.science/" target="_blank" rel="noopener noreferrer">AISC</a></small>
+          <div class="links">
+            <a href="../assets/pdf/tgn_aisc_2020.pdf" class="btn btn-sm z-depth-0" role="button">Slides</a>
+            <a href="https://www.youtube.com/watch?v=W1GvX2ZcUmY" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a>
+          </div>
         </td>
       </tr>
     </tbody>
@@ -166,16 +180,20 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
         <td class="text-nowrap" style="width:5rem"><small class="text-muted">2021/03/02</small></td>
         <td>
           <em>Scaling Graph Neural Networks to Twitter-scale</em><br>
-          <small>with <a href="https://www.youtube.com/channel/UCxw9_WYmLqlj5PyXu2AWU_g" target="_blank" rel="noopener noreferrer">Zak Jost</a></small><br>
-          <a href="https://www.youtube.com/watch?v=ZSMEXchR3w8" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a>
+          <small>with <a href="https://www.youtube.com/channel/UCxw9_WYmLqlj5PyXu2AWU_g" target="_blank" rel="noopener noreferrer">Zak Jost</a></small>
+          <div class="links">
+            <a href="https://www.youtube.com/watch?v=ZSMEXchR3w8" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video</a>
+          </div>
         </td>
       </tr>
       <tr>
         <td class="text-nowrap"><small class="text-muted">2021/01/14</small></td>
         <td>
           <em>My journey, my research at Twitter and Imperial College, and my work at LeadTheFuture</em><br>
-          <small>with <a href="https://italia-podcast.it/podcast/smarter-podcast" target="_blank" rel="noopener noreferrer">The Smarter Podcast</a></small><br>
-          <a href="https://www.youtube.com/watch?v=x4CeQ3S_DCA" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video <small class="text-muted">it</small></a>
+          <small>with <a href="https://italia-podcast.it/podcast/smarter-podcast" target="_blank" rel="noopener noreferrer">The Smarter Podcast</a></small>
+          <div class="links">
+            <a href="https://www.youtube.com/watch?v=x4CeQ3S_DCA" target="_blank" rel="noopener noreferrer" class="btn btn-sm z-depth-0" role="button">Video <small class="text-muted">it</small></a>
+          </div>
         </td>
       </tr>
     </tbody>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -105,3 +105,22 @@ h2.category {
     }
   }
 }
+
+// Bordered link buttons for standalone .links divs (e.g. outreach page)
+// Mirrors the scoped rule in _publications.scss which only applies inside .publications ol.bibliography li
+.links {
+  a.btn {
+    color: var(--global-text-color);
+    border: 1px solid var(--global-text-color);
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+    margin-left: 0;
+
+    &:hover {
+      color: var(--global-theme-color);
+      border-color: var(--global-theme-color);
+    }
+  }
+}

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -82,6 +82,17 @@ html[data-theme="dark"] {
   }
 }
 
+// Standalone section divider — matches the .projects h2.category pattern
+// but usable on any page (e.g. outreach)
+h2.category {
+  color: var(--global-divider-color);
+  border-bottom: 1px solid var(--global-divider-color);
+  padding-top: 0.5rem;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  text-align: right;
+}
+
 .publications {
   ol.bibliography {
     li {

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -93,6 +93,17 @@ h2.category {
   text-align: right;
 }
 
+// Year sub-dividers — muted label style, visually subordinate to h2.category
+h3.year {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--global-text-color-light);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
 .publications {
   ol.bibliography {
     li {


### PR DESCRIPTION
## Summary

- Add standalone `h2.category` CSS rule to `_custom.scss` so the right-aligned section divider (previously only scoped inside `.projects`) works on any page
- Convert all `##` section headings on the outreach page to `<h2 class="category">` for visual consistency with the rest of the site
- Replace year-bucketed bullet lists in the Talks and Conversations sections with responsive `table-sm table-borderless` tables, grouped by year with `.year` dividers (date · title+venue · links columns)
- Mentoring section kept as plain Markdown list (no structural changes)

## Test plan

- [x] Run `docker compose up` and visit `http://localhost:8080/outreach/`
- [x] Verify section dividers render as right-aligned labels with horizontal rules
- [x] Verify talk tables are scannable on desktop (3 columns) and collapse gracefully on mobile
- [x] Toggle dark mode — check divider colours and muted text
- [x] Confirm all slides/video links are clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)