### PR TITLE
Align outreach headings with about/publications

### DIFF
--- a/_pages/outreach.md
+++ b/_pages/outreach.md
@@ -11,11 +11,12 @@ nav_order: 4
 
 <div class="projects">
 
-<h2 class="category">Talks</h2>
+<h2>Talks</h2>
 
 Invited talks and presentations at academic seminars, workshops, and industry events.
 
-<h3 class="year">2023</h3>
+<div class="publications">
+<h2 class="bibliography">2023</h2>
 
 <div class="table-responsive">
   <table class="table table-sm table-borderless">
@@ -52,7 +53,7 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
   </table>
 </div>
 
-<h3 class="year">2022</h3>
+<h2 class="bibliography">2022</h2>
 
 <div class="table-responsive">
   <table class="table table-sm table-borderless">
@@ -96,7 +97,7 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
   </table>
 </div>
 
-<h3 class="year">2021</h3>
+<h2 class="bibliography">2021</h2>
 
 <div class="table-responsive">
   <table class="table table-sm table-borderless">
@@ -153,7 +154,7 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
   </table>
 </div>
 
-<h3 class="year">2020</h3>
+<h2 class="bibliography">2020</h2>
 
 <div class="table-responsive">
   <table class="table table-sm table-borderless">
@@ -173,7 +174,9 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
   </table>
 </div>
 
-<h2 class="category">Conversations</h2>
+</div>
+
+<h2>Conversations</h2>
 
 <div class="table-responsive">
   <table class="table table-sm table-borderless">
@@ -202,7 +205,7 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
   </table>
 </div>
 
-<h2 class="category">Workshop Involvement</h2>
+<h2>Workshop Involvement</h2>
 
 <div class="table-responsive">
   <table class="table table-sm table-borderless">
@@ -253,9 +256,9 @@ Invited talks and presentations at academic seminars, workshops, and industry ev
   </table>
 </div>
 
-<h2 class="category">Supervision and Mentoring</h2>
+<h2>Supervision and Mentoring</h2>
 
-Mentoring bright and motivated students is one of the most rewarding aspects of my research. I am grateful for their creativity and curiosity, and for how much I learn from them in return.<br>
+<p>Mentoring bright and motivated students is one of the most rewarding aspects of my research. I am grateful for their creativity and curiosity, and for how much I learn from them in return.</p>
 
 Below are the students I have had the pleasure to supervise.
 If you are a <strong>prospective student interested in working with me</strong>, feel free to contact my former mentees to learn more about my mentoring style and what collaboration with me looks like.

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -82,17 +82,6 @@ html[data-theme="dark"] {
   }
 }
 
-// Year sub-dividers — muted label style, visually subordinate to h2.category
-h3.year {
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: var(--global-text-color-light);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  margin-top: 1.5rem;
-  margin-bottom: 0.5rem;
-}
-
 .publications {
   ol.bibliography {
     li {


### PR DESCRIPTION
## Summary
- Make outreach section titles use plain h2 styling like the about page so they are more prominent and readable.
- Change talks year headings on outreach to use the same h2.bibliography markup and .publications styling as the publications page.
- Ensure horizontal divider lines only appear at year boundaries in the talks section, not under section titles.

## Test plan
- Run `docker compose up --build` and open `/outreach/`.
  - Verify `Talks`, `Conversations`, `Workshop Involvement`, and `Supervision and Mentoring` render as standard h2 section titles (no grey right-aligned headers with lines).
  - Verify the talks years (2023, 2022, 2021, 2020) look identical in size, color, and divider line treatment to the years on `/publications/`.
  - Confirm horizontal lines only divide years in the talks section.
- Open `/publications/` and spot-check that publication year headings are unchanged.

Made with [Cursor](https://cursor.com)