### PR TITLE
style: soften publication badges

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit*)",
+            "command": "jq -r '.tool_input.command' | grep -q 'git commit' && npx prettier . --write 2>/dev/null || true",
+            "statusMessage": "Running prettier before commit..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/add-paper/SKILL.md
+++ b/.claude/skills/add-paper/SKILL.md
@@ -8,6 +8,7 @@ Add the paper(s) provided by the user to `_bibliography/papers.bib`. Follow thes
 ## Step 1 — Fetch metadata
 
 Fetch the paper's abstract page (arXiv, ACL Anthology, NeurIPS proceedings, etc.) and extract:
+
 - Title
 - Authors (full names, in order)
 - Year

--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -41,7 +41,7 @@ If the merge stops due to conflicts, do not abort. For every conflicting file, a
 3.  Once all conflicts are resolved, commit the merge with the message: "chore: sync with upstream al-folio".
 4.  **Build & Verify locally before pushing:**
     - Run `docker compose up --build -d` and wait for the server to be ready: `until docker compose logs 2>&1 | grep -q "Server running"; do sleep 5; done`
-    - Invoke the `/verify` skill with this prompt: *"Check that the site at http://localhost:8080 is working correctly after an upstream sync. Verify: home page loads, navigation works, publications page renders, CV page renders, dark mode toggle works, no JS errors in console. Report any regressions."*
+    - Invoke the `/verify` skill with this prompt: _"Check that the site at http://localhost:8080 is working correctly after an upstream sync. Verify: home page loads, navigation works, publications page renders, CV page renders, dark mode toggle works, no JS errors in console. Report any regressions."_
     - If `/verify` returns FAIL or BLOCKED, attempt to fix the issue and amend the commit before proceeding.
     - If an issue cannot be resolved automatically, stop and report it to me with a clear description before proceeding.
 5.  Push the branch to origin: `git push origin <branch-name>`.

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -16,79 +16,144 @@
   margin-bottom: 0.5rem;
 
   .badge {
-    font-size: 0.75rem;
-    font-weight: 500;
-    padding: 0.25rem 0.5rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    padding: 0.2rem 0.5rem;
     margin-bottom: 0.25rem;
-    border-radius: 0.25rem;
+    border-radius: 0.3rem;
+    border: 1px solid transparent;
     display: block;
     width: 100%;
     text-align: center;
   }
 
+  // !important needed on all properties to override mdbootstrap's .badge { color/bg: !important }
   .badge-conference {
-    background-color: #007bff;
-    color: white;
+    background-color: #d4e4fd !important;
+    color: #1248a0 !important;
+    border-color: #a8caf9 !important;
   }
 
   .badge-workshop {
-    background-color: #28a745;
-    color: white;
+    background-color: #d1ead2 !important;
+    color: #1b5e20 !important;
+    border-color: #a8d5aa !important;
   }
 
   .badge-journal {
-    background-color: #dc3545;
-    color: white;
+    background-color: #f9d5db !important;
+    color: #921924 !important;
+    border-color: #f0a8b2 !important;
   }
 
   .badge-preprint {
-    background-color: #ffc107;
-    color: #212529;
+    background-color: #fee8c0 !important;
+    color: #924600 !important;
+    border-color: #fcc878 !important;
   }
 
   .badge-default {
-    background-color: #6c757d;
-    color: white;
+    background-color: #e8eef4 !important;
+    color: #374151 !important;
+    border-color: #cdd6e0 !important;
   }
 }
 
 // Dark mode adaptations for publication type badges
+// Deep saturated backgrounds + bright colored text for a vivid but legible dark-mode look
 html[data-theme="dark"] {
   .pubtype-tags {
     .badge-conference {
-      background-color: #4dabf7;
-      color: var(--global-card-bg-color) !important;
+      background-color: #1a4a7a !important;
+      color: #7ec8ff !important;
+      border-color: #2a6aaa !important;
     }
 
     .badge-workshop {
-      background-color: #51cf66;
-      color: var(--global-card-bg-color) !important;
+      background-color: #1a5228 !important;
+      color: #7de89a !important;
+      border-color: #267838 !important;
     }
 
     .badge-journal {
-      background-color: #ff6b6b;
-      color: var(--global-card-bg-color) !important;
+      background-color: #6e1a22 !important;
+      color: #ffaab0 !important;
+      border-color: #962430 !important;
     }
 
     .badge-preprint {
-      background-color: #ffd43b;
-      color: var(--global-card-bg-color) !important;
+      background-color: #6e3e00 !important;
+      color: #ffe08a !important;
+      border-color: #9e5a00 !important;
     }
 
     .badge-default {
-      background-color: #868e96;
-      color: var(--global-card-bg-color) !important;
+      background-color: #38424e !important;
+      color: #c0ccd8 !important;
+      border-color: #4e5c6a !important;
     }
   }
 }
 
+// Soft venue badge (the abbr pill above the teaser image) and soft award badge
+// Overrides the solid theme-color fill from _publications.scss
 .publications {
   ol.bibliography {
     li {
+      .abbr {
+        abbr {
+          background-color: color-mix(in srgb, var(--global-theme-color) 16%, white) !important;
+          color: color-mix(in srgb, var(--global-theme-color) 85%, black) !important;
+          border: 1px solid color-mix(in srgb, var(--global-theme-color) 32%, white) !important;
+
+          a {
+            color: color-mix(in srgb, var(--global-theme-color) 85%, black) !important;
+          }
+        }
+
+      }
+
+      // Award badge (e.g. "SPOTLIGHT (TOP 15%)") — inline style in bib.liquid, needs !important to override
       .links {
+        a.btn[style*="background-color"] {
+          background-color: color-mix(in srgb, var(--global-theme-color) 16%, white) !important;
+          color: color-mix(in srgb, var(--global-theme-color) 85%, black) !important;
+          border: 1px solid color-mix(in srgb, var(--global-theme-color) 32%, white) !important;
+        }
+
         a.btn {
           padding-left: 0.5rem;
           padding-right: 0.5rem;
+        }
+      }
+    }
+  }
+}
+
+html[data-theme="dark"] {
+  .publications {
+    ol.bibliography {
+      li {
+        .abbr {
+          abbr {
+            background-color: color-mix(in srgb, var(--global-theme-color) 35%, var(--global-card-bg-color)) !important;
+            color: color-mix(in srgb, var(--global-theme-color) 40%, white) !important;
+            border: 1px solid color-mix(in srgb, var(--global-theme-color) 55%, var(--global-card-bg-color)) !important;
+
+            a {
+              color: color-mix(in srgb, var(--global-theme-color) 40%, white) !important;
+            }
+          }
+
+        }
+
+        .links {
+          a.btn[style*="background-color"] {
+            background-color: color-mix(in srgb, var(--global-theme-color) 70%, var(--global-card-bg-color)) !important;
+            color: white !important;
+            border: 1px solid color-mix(in srgb, var(--global-theme-color) 85%, var(--global-card-bg-color)) !important;
+          }
         }
       }
     }

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -111,7 +111,6 @@ html[data-theme="dark"] {
             color: color-mix(in srgb, var(--global-theme-color) 85%, black) !important;
           }
         }
-
       }
 
       // Award badge (e.g. "SPOTLIGHT (TOP 15%)") — inline style in bib.liquid, needs !important to override
@@ -145,7 +144,6 @@ html[data-theme="dark"] {
               color: color-mix(in srgb, var(--global-theme-color) 40%, white) !important;
             }
           }
-
         }
 
         .links {

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -10,7 +10,28 @@
   }
 }
 
+// Base hues for publication type badges
+$badge-conference-hue: #1565c0;
+$badge-workshop-hue: #2e7d32;
+$badge-journal-hue: #c62828;
+$badge-preprint-hue: #e65100;
+$badge-default-hue: #546e7a;
+
+// Same tinting formula used for the venue abbr pill and award badge below
+@mixin soft-badge($hue) {
+  background-color: color-mix(in srgb, #{$hue} 16%, white) !important;
+  color: color-mix(in srgb, #{$hue} 85%, black) !important;
+  border-color: color-mix(in srgb, #{$hue} 32%, white) !important;
+}
+
+@mixin soft-badge-dark($hue) {
+  background-color: color-mix(in srgb, #{$hue} 35%, var(--global-card-bg-color)) !important;
+  color: color-mix(in srgb, #{$hue} 40%, white) !important;
+  border-color: color-mix(in srgb, #{$hue} 55%, var(--global-card-bg-color)) !important;
+}
+
 // Publication Type Badges
+// !important needed on all color properties to override mdbootstrap's .badge { color/bg: !important }
 .pubtype-tags {
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
@@ -28,130 +49,84 @@
     text-align: center;
   }
 
-  // !important needed on all properties to override mdbootstrap's .badge { color/bg: !important }
   .badge-conference {
-    background-color: #d4e4fd !important;
-    color: #1248a0 !important;
-    border-color: #a8caf9 !important;
+    @include soft-badge($badge-conference-hue);
   }
-
   .badge-workshop {
-    background-color: #d1ead2 !important;
-    color: #1b5e20 !important;
-    border-color: #a8d5aa !important;
+    @include soft-badge($badge-workshop-hue);
   }
-
   .badge-journal {
-    background-color: #f9d5db !important;
-    color: #921924 !important;
-    border-color: #f0a8b2 !important;
+    @include soft-badge($badge-journal-hue);
   }
-
   .badge-preprint {
-    background-color: #fee8c0 !important;
-    color: #924600 !important;
-    border-color: #fcc878 !important;
+    @include soft-badge($badge-preprint-hue);
   }
-
   .badge-default {
-    background-color: #e8eef4 !important;
-    color: #374151 !important;
-    border-color: #cdd6e0 !important;
+    @include soft-badge($badge-default-hue);
   }
 }
 
-// Dark mode adaptations for publication type badges
-// Deep saturated backgrounds + bright colored text for a vivid but legible dark-mode look
-html[data-theme="dark"] {
-  .pubtype-tags {
-    .badge-conference {
-      background-color: #1a4a7a !important;
-      color: #7ec8ff !important;
-      border-color: #2a6aaa !important;
-    }
-
-    .badge-workshop {
-      background-color: #1a5228 !important;
-      color: #7de89a !important;
-      border-color: #267838 !important;
-    }
-
-    .badge-journal {
-      background-color: #6e1a22 !important;
-      color: #ffaab0 !important;
-      border-color: #962430 !important;
-    }
-
-    .badge-preprint {
-      background-color: #6e3e00 !important;
-      color: #ffe08a !important;
-      border-color: #9e5a00 !important;
-    }
-
-    .badge-default {
-      background-color: #38424e !important;
-      color: #c0ccd8 !important;
-      border-color: #4e5c6a !important;
-    }
-  }
-}
-
-// Soft venue badge (the abbr pill above the teaser image) and soft award badge
-// Overrides the solid theme-color fill from _publications.scss
+// Venue abbr pill and award badge — soft tint using theme color
+// Overrides solid fill from _publications.scss; award badge also needs !important to beat bib.liquid inline styles
 .publications {
   ol.bibliography {
     li {
-      .abbr {
-        abbr {
-          background-color: color-mix(in srgb, var(--global-theme-color) 16%, white) !important;
-          color: color-mix(in srgb, var(--global-theme-color) 85%, black) !important;
-          border: 1px solid color-mix(in srgb, var(--global-theme-color) 32%, white) !important;
-
-          a {
-            color: color-mix(in srgb, var(--global-theme-color) 85%, black) !important;
-          }
-        }
+      .abbr abbr,
+      .links a.btn[style*="background-color"] {
+        background-color: color-mix(in srgb, var(--global-theme-color) 16%, white) !important;
+        color: color-mix(in srgb, var(--global-theme-color) 85%, black) !important;
+        border: 1px solid color-mix(in srgb, var(--global-theme-color) 32%, white) !important;
       }
 
-      // Award badge (e.g. "SPOTLIGHT (TOP 15%)") — inline style in bib.liquid, needs !important to override
-      .links {
-        a.btn[style*="background-color"] {
-          background-color: color-mix(in srgb, var(--global-theme-color) 16%, white) !important;
-          color: color-mix(in srgb, var(--global-theme-color) 85%, black) !important;
-          border: 1px solid color-mix(in srgb, var(--global-theme-color) 32%, white) !important;
-        }
+      .abbr abbr a {
+        color: color-mix(in srgb, var(--global-theme-color) 85%, black) !important;
+      }
 
-        a.btn {
-          padding-left: 0.5rem;
-          padding-right: 0.5rem;
-        }
+      .links a.btn {
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
       }
     }
   }
 }
 
+// Dark mode overrides for all publication badges
 html[data-theme="dark"] {
+  .pubtype-tags {
+    .badge-conference {
+      @include soft-badge-dark($badge-conference-hue);
+    }
+    .badge-workshop {
+      @include soft-badge-dark($badge-workshop-hue);
+    }
+    .badge-journal {
+      @include soft-badge-dark($badge-journal-hue);
+    }
+    .badge-preprint {
+      @include soft-badge-dark($badge-preprint-hue);
+    }
+    .badge-default {
+      @include soft-badge-dark($badge-default-hue);
+    }
+  }
+
   .publications {
     ol.bibliography {
       li {
-        .abbr {
-          abbr {
-            background-color: color-mix(in srgb, var(--global-theme-color) 35%, var(--global-card-bg-color)) !important;
-            color: color-mix(in srgb, var(--global-theme-color) 40%, white) !important;
-            border: 1px solid color-mix(in srgb, var(--global-theme-color) 55%, var(--global-card-bg-color)) !important;
+        .abbr abbr {
+          background-color: color-mix(in srgb, var(--global-theme-color) 35%, var(--global-card-bg-color)) !important;
+          color: color-mix(in srgb, var(--global-theme-color) 40%, white) !important;
+          border: 1px solid color-mix(in srgb, var(--global-theme-color) 55%, var(--global-card-bg-color)) !important;
 
-            a {
-              color: color-mix(in srgb, var(--global-theme-color) 40%, white) !important;
-            }
+          a {
+            color: color-mix(in srgb, var(--global-theme-color) 40%, white) !important;
           }
         }
 
-        .links {
-          a.btn[style*="background-color"] {
-            background-color: color-mix(in srgb, var(--global-theme-color) 70%, var(--global-card-bg-color)) !important;
-            color: white !important;
-            border: 1px solid color-mix(in srgb, var(--global-theme-color) 85%, var(--global-card-bg-color)) !important;
-          }
+        .links a.btn[style*="background-color"] {
+          background-color: color-mix(in srgb, var(--global-theme-color) 70%, var(--global-card-bg-color)) !important;
+          color: white !important;
+          border: 1px solid color-mix(in srgb, var(--global-theme-color) 85%, var(--global-card-bg-color)) !important;
         }
       }
     }


### PR DESCRIPTION
## Summary

- **Venue badges** (`abbr`): replaced solid theme-color fill with soft tint + colored text via `color-mix()` (light mode); deep saturated background + bright colored text (dark mode)
- **Type badges** (Conference, Workshop, Journal, Preprint, Thesis): soft tinted backgrounds + dark colored text (light mode); jewel-tone backgrounds + bright colored text (dark mode)
- **Award/SPOTLIGHT badge**: same soft treatment, overriding the hardcoded inline `style=` in `bib.liquid` via `!important`
- Added `!important` on all badge color/background/border properties to beat mdbootstrap's `.badge { color/bg: !important }`

## Test plan

- [ ] Visit `/publications/` in light mode — venue badges, type badges, and SPOTLIGHT badge all show soft tinted backgrounds with readable colored text
- [ ] Switch to dark mode — all badges show deep saturated backgrounds with bright colored text; SPOTLIGHT badge shows white text on teal background
- [ ] Check the thesis entry — "PhD Thesis" venue badge and "Thesis" type badge both render correctly in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)