### PR TITLE
[codex] Add publication topic filters

### DIFF
--- a/LOCAL_AGENTS.md
+++ b/LOCAL_AGENTS.md
@@ -13,3 +13,7 @@ Always use `gh pr create --repo emalgorithm/emalgorithm.github.io` — the `upst
 ## Presentations
 
 Slide files live in `assets/presentations/` and are committed as regular git objects (not LFS — GitHub Pages does not serve LFS files). Name files `{topic}_{venue}_{date}` in lowercase with underscores; HTML and PDF share the same base name. In `_data/outreach.yml`, add a `# source: <commit-url>` comment below the slide URL pointing to the exact commit that generated the slides.
+
+## Publications
+
+When adding custom fields to `_bibliography/papers.bib`, add them to `filtered_bibtex_keywords` in `_config.yml` unless they should intentionally appear in exported BibTeX.

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -11,6 +11,7 @@
   website     = {https://erodola.github.io/lac-demo/},
   xthread     = {https://x.com/emaros96/status/2059989582855254274},
   pubtype     = {preprint},
+  topics      = {animal-communication},
   bibtex_show = {true},
   selected    = {true},
   abstract    = {We introduce lexical acoustic coding (LAC), a framework that enables LLM agents to transmit audio through natural language. A sender converts a waveform into interpretable, non-learned acoustic descriptors, quantizes each with a feature-specific interval vocabulary, and verbalizes the result as a plain English sentence. The receiver parses the sentence back into labels, inverts each label to an interval target, and renders a waveform via a decoder with closed-loop refinement. We frame LAC as a finite-rate lossy quantizer, exposing trade-offs among vocabulary size, transmission rate, and audio fidelity, and show that plain text can preserve enough acoustic information for intelligible reconstruction while remaining human-readable and editable.}
@@ -29,6 +30,7 @@
   dataset     = {https://huggingface.co/datasets/Amboss-Tech/ln-gossip},
   xthread     = {https://x.com/ambosstech/status/2056751895692431520?s=20},
   pubtype     = {preprint},
+  topics      = {lightning-network, graphs},
   bibtex_show = {true},
   abstract    = {We study the problem of predicting channel closure types in the Lightning Network using machine learning. We construct a dataset from two years of network activity and benchmark multiple approaches including MLPs and temporal graph neural networks. Our findings show that temporal and behavioural factors—specifically node activity recency and closure history—are the primary drivers of predictive performance, outweighing network topology. A simple MLP surpasses graph-based models, highlighting how the network's privacy constraints limit what is predictable from publicly available data alone. We release our dataset and code to support future research.}
 }
@@ -46,6 +48,7 @@
   preview     = {graph_imputation_multimodal.png},
   bibtex_show = {true},
   pubtype     = {journal},
+  topics      = {graphs},
   abstract    = {Multimodal recommender systems (RSs) represent items in the catalog through multimodal data (e.g., product images and descriptions) that, in some cases, might be noisy or (even worse) missing. In those scenarios, the common practice is to drop items with missing modalities and train the multimodal RSs on a subsample of the original dataset. To date, the problem of missing modalities in multimodal recommendation has still received limited attention in the literature, lacking a precise formalisation as done with missing information in traditional machine learning. In this work, we first provide a problem formalisation for missing modalities in multimodal recommendation. Second, by leveraging the user-item graph structure, we re-cast the problem of missing multimodal information as a problem of graph features interpolation on the item-item co-purchase graph. On this basis, we propose four training-free approaches that propagate the available multimodal features throughout the item-item graph to impute the missing features. Extensive experiments on popular multimodal recommendation datasets demonstrate that our solutions can be seamlessly plugged into any existing multimodal RS and benchmarking framework while still preserving (or even widen) the performance gap between multimodal and traditional RSs. Moreover, we show that our graph-based techniques can perform better than traditional imputations in machine learning under different missing modalities settings. Finally, we analyse (for the first time in multimodal RSs) how feature homophily calculated on the item-item graph can influence our graph-based imputations.}
 }
 
@@ -62,6 +65,7 @@
   abbr        = {Scientific Reports},
   preview     = {sperm_whale_unit_a_sci_rep_2026.png},
   pubtype     = {journal},
+  topics      = {animal-communication},
   bibtex_show = {true},
   abstract    = {Wild cetacean birth observations are extremely rare, with observations having been recorded in less than 10\% of cetacean species. Here, we describe a detailed accounting of a sperm whale (Physeter macrocephalus) birth off the coast of Dominica within a well-documented social unit and consisted of sperm whales collaboratively lifting the newborn out of the water. We recorded data via multiple concurrent methods: underwater audio, aerial drone video, shipboard photography in addition to behavioral observations spanning before, during and after the whale birth. All 11 members from sperm whale Unit A were present and participated in the birth, which lasted 34 min from the time the flukes emerged until the completion of delivery. The sperm whale unit made extensive vocalizations, with statistically significant shifts in coda vocal style corresponding to key events, such as the beginning of the birth and interactions with short-finned pilot whales (Globicephala macrorhynchus) shortly after the birth event. An evolutionary analysis of wild cetacean births suggests that newborns being lifted out of the water dates to before the most recent common ancestor of toothed and baleen whales, $>$ 36 million years ago, and that cooperative lifting of the newborn is noted, thus far, only in members of Odontoceti (toothed whales). This study provides the most in-depth observations of a wild cetacean birth.}
 }
@@ -79,6 +83,7 @@
   code        = {https://github.com/gladia-research-group/model-merging-NatureLM-audio},
   xthread     = {https://x.com/GladiaLab/status/1991161421288165641?s=20},
   pubtype     = {workshop},
+  topics      = {animal-communication},
   bibtex_show = {true},
   abstract    = {Foundation models capable of generalizing across species and tasks represent a promising new frontier in bioacoustics, with NatureLM being one of the most prominent examples. While its domain-specific fine-tuning yields strong performance on bioacoustic benchmarks, we observe that it also introduces trade-offs in instruction-following flexibility. For instance, NatureLM achieves high accuracy when prompted for either the common or scientific name individually, but its accuracy drops significantly when both are requested in a single prompt. We address this by applying a simple model merging strategy that interpolates NatureLM with its base language model, recovering instruction-following capabilities with minimal loss of domain expertise. Finally, we show that the merged model exhibits markedly stronger zero-shot generalization, achieving over a 200% relative improvement and setting a new state-of-the-art in closed-set zero-shot classification of unseen species.},
   selected    = {true},
@@ -97,6 +102,7 @@
   abbr        = {Algorithms},
   preview     = {bayesian.png},
   pubtype     = {journal},
+  topics      = {lightning-network},
   bibtex_show = {true},
   abstract    = {We present Bayesian Binary Search (BBS), a novel probabilistic variant of the classical binary search/bisection algorithm. BBS leverages machine learning/statistical techniques to estimate the probability density of the search space and modifies the bisection step to split based on probability density rather than the traditional midpoint, allowing for the learned distribution of the search space to guide the search algorithm. Search space density estimation can flexibly be performed using supervised probabilistic machine learning techniques (e.g., Gaussian process regression, Bayesian neural networks, quantile regression) or unsupervised learning algorithms (e.g., Gaussian mixture models, kernel density estimation (KDE), maximum likelihood estimation (MLE)). We demonstrate significant efficiency gains of using BBS on both simulated data across a variety of distributions and in a real-world binary search use case of probing channel balances in the Bitcoin Lightning Network, for which we have deployed the BBS algorithm in a production setting.}
 }
@@ -111,6 +117,7 @@
   abbr        = {ICBC},
   preview     = {lightning.png},
   pubtype     = {conference},
+  topics      = {lightning-network, graphs},
   bibtex_show = {true},
   abstract    = {The Bitcoin Lightning Network is a Layer 2 payment protocol that addresses Bitcoin's scalability by facilitating quick and cost effective transactions through payment channels. This research explores the feasibility of using machine learning models to interpolate channel balances within the network, which can be used for optimizing the network's pathfinding algorithms. While there has been much exploration in balance probing and multipath payment protocols, predicting channel balances using solely node and channel features remains an uncharted area. This paper evaluates the performance of several machine learning models against two heuristic baselines and investigates the predictive capabilities of various features. Our model performs favorably in experimental evaluation, outperforming by 10% against an equal split baseline where both edges are assigned half of the channel capacity.}
 }
@@ -129,6 +136,7 @@
   code        = {https://github.com/shenyangHuang/TGB},
   website     = {https://tgb.complexdatalab.com/},
   pubtype     = {conference},
+  topics      = {graphs},
   bibtex_show = {true},
   abstract    = {Multi-relational temporal graphs are powerful tools for modeling real-world data, capturing the evolving and interconnected nature of entities over time. Recently, many novel models are proposed for ML on such graphs intensifying the need for robust evaluation and standardized benchmark datasets. However, the availability of such resources remains scarce and evaluation faces added complexity due to reproducibility issues in experimental protocols. To address these challenges, we introduce Temporal Graph Benchmark 2.0 (TGB 2.0), a novel benchmarking framework tailored for evaluating methods for predicting future links on Temporal Knowledge Graphs and Temporal Heterogeneous Graphs with a focus on large-scale datasets, extending the Temporal Graph Benchmark. TGB 2.0 facilitates comprehensive evaluations by presenting eight novel datasets spanning five domains with up to 53 million edges. TGB 2.0 datasets are significantly larger than existing datasets in terms of number of nodes, edges, or timestamps. In addition, TGB 2.0 provides a reproducible and realistic evaluation pipeline for multi-relational temporal graphs. Through extensive experimentation, we observe that 1) leveraging edge-type information is crucial to obtain high performance, 2) simple heuristic baselines are often competitive with more complex methods, 3) most methods fail to run on our largest datasets, highlighting the need for research on more scalable methods.}
 }
@@ -144,6 +152,7 @@
   abbr        = {ACM},
   preview     = {multimodal.png},
   pubtype     = {conference},
+  topics      = {graphs},
   bibtex_show = {true},
   abstract    = {Generally, items with missing modalities are dropped in multimodal recommendation. However, with this work, we question this procedure, highlighting that it would further damage the pipeline of any multimodal recommender system. First, we show that the lack of (some) modalities is, in fact, a widely-diffused phenomenon in multimodal recommendation. Second, we propose a pipeline that imputes missing multimodal features in recommendation by leveraging traditional imputation strategies in machine learning. Then, given the graph structure of the recommendation data, we also propose three more effective imputation solutions that leverage the item-item co-purchase graph and the multimodal similarities of co-interacted items. Our method can be plugged into any multimodal RSs in the literature working as an untrained pre-processing phase, showing (through extensive experiments) that any data pre-filtering is not only unnecessary but also harmful to the performance.}
 }
@@ -160,6 +169,7 @@
   code        = {https://github.com/pinder-org/pinder},
   docs        = {https://pinder-org.github.io/pinder},
   pubtype     = {preprint},
+  topics      = {molecular-biology},
   bibtex_show = {true},
   abstract    = {Protein-protein interactions (PPIs) are fundamental to understanding biological processes and play a key role in therapeutic advancements. As deep-learning docking methods for PPIs gain traction, benchmarking protocols and datasets tailored for effective training and evaluation of their generalization capabilities and performance across real-world scenarios become imperative. Aiming to overcome limitations of existing approaches, we introduce PINDER, a comprehensive annotated dataset that uses structural clustering to derive non-redundant interface-based data splits and includes holo (bound), apo (unbound), and computationally predicted structures. PINDER consists of 2,319,564 dimeric PPI systems (and up to 25 million augmented PPIs) and 1,955 high-quality test PPIs with interface data leakage removed. Additionally, PINDER provides a test subset with 180 dimers for comparison to AlphaFold-Multimer without any interface leakage with respect to its training set. Unsurprisingly, the PINDER benchmark reveals that the performance of existing docking models is highly overestimated when evaluated on leaky test sets. Most importantly, by retraining DiffDock-PP on PINDER interface-clustered splits, we show that interface cluster-based sampling of the training split, along with the diverse and less leaky validation split, leads to strong generalization improvements.}
 }
@@ -176,6 +186,7 @@
   dataset     = {https://console.cloud.google.com/storage/browser/plinder},
   docs        = {https://plinder-org.github.io/plinder},
   pubtype     = {workshop},
+  topics      = {molecular-biology},
   bibtex_show = {true},
   abstract    = {Protein-protein interactions (PPIs) are fundamental to understanding biological processes and play a key role in therapeutic advancements. As deep-learning docking methods for PPIs gain traction, benchmarking protocols and datasets tailored for effective training and evaluation of their generalization capabilities and performance across real-world scenarios become imperative. Aiming to overcome limitations of existing approaches, we introduce PINDER, a comprehensive annotated dataset that uses structural clustering to derive non-redundant interface-based data splits and includes holo (bound), apo (unbound), and computationally predicted structures. PINDER consists of 2,319,564 dimeric PPI systems (and up to 25 million augmented PPIs) and 1,955 high-quality test PPIs with interface data leakage removed. Additionally, PINDER provides a test subset with 180 dimers for comparison to AlphaFold-Multimer without any interface leakage with respect to its training set. Unsurprisingly, the PINDER benchmark reveals that the performance of existing docking models is highly overestimated when evaluated on leaky test sets. Most importantly, by retraining DiffDock-PP on PINDER interface-clustered splits, we show that interface cluster-based sampling of the training split, along with the diverse and less leaky validation split, leads to strong generalization improvements.}
 }
@@ -191,6 +202,7 @@
   preview     = {utg.png},
   video       = {https://www.youtube.com/watch?v=zLfzIIRj5uo},
   pubtype     = {conference},
+  topics      = {graphs},
   bibtex_show = {true},
   selected    = {true},
   abstract    = {Many real world graphs are inherently dynamic, constantly evolving with node and edge additions. These graphs can be represented by temporal graphs, either through a stream of edge events or a sequence of graph snapshots. Until now, the development of machine learning methods for both types has occurred largely in isolation, resulting in limited experimental comparison and theoretical crosspollination between the two. In this paper, we introduce Unified Temporal Graph (UTG), a framework that unifies snapshot-based and event-based machine learning models under a single umbrella, enabling models developed for one representation to be applied effectively to datasets of the other. We also propose a novel UTG training procedure to boost the performance of snapshot-based models in the streaming setting. We comprehensively evaluate both snapshot and event-based models across both types of temporal graphs on the temporal link prediction task. Our main findings are threefold: first, when combined with UTG training, snapshot-based models can perform competitively with event-based models such as TGN and GraphMixer even on event datasets. Second, snapshot-based models are at least an order of magnitude faster than most event-based models during inference. Third, while event-based methods such as NAT and DyGFormer outperforms snapshot-based methods on both types of temporal graphs, this is because they leverage joint neighborhood structural features thus emphasizing the potential to incorporate these features into snapshotbased models as well. These findings highlight the importance of comparing model architectures independent of the data format and suggest the potential of combining the efficiency of snapshot-based models with the performance of event-based models in the future.}
@@ -207,6 +219,7 @@
   abbr        = {PhD Thesis},
   selected    = {false},
   pubtype     = {thesis},
+  topics      = {graphs},
   bibtex_show = {true},
   preview     = {thesis.png},
   abstract    = {Graph Neural Networks (GNNs) have become a central tool for learning on graph-structured data, yet their applicability to real-world systems remains limited by key challenges such as scalability, temporality, directionality, data incompleteness, and structural uncertainty. This thesis introduces a series of models addressing these limitations: SIGN for scalable graph learning, TGN for temporal graphs, Dir-GNN for directed and heterophilic networks, Feature Propagation (FP) for learning with missing node features, and NuGget for game-theoretic structural inference. Together, these contributions bridge the gap between academic benchmarks and industrial-scale graphs, enabling the use of GNNs in domains such as social and recommender systems.}
@@ -226,6 +239,7 @@
   selected    = {true},
   preview     = {tgb.png},
   pubtype     = {conference},
+  topics      = {graphs},
   bibtex_show = {true},
   abstract    = {We present the Temporal Graph Benchmark (TGB), a collection of challenging and diverse benchmark datasets for realistic, reproducible, and robust evaluation of machine learning models on temporal graphs. TGB datasets are of large scale, spanning years in duration, incorporate both node and edge-level prediction tasks and cover a diverse set of domains including social, trade, transaction, and transportation networks. For both tasks, we design evaluation protocols based on realistic use-cases. We extensively benchmark each dataset and find that the performance of common models can vary drastically across datasets. In addition, on dynamic node property prediction tasks, we show that simple methods often achieve superior performance compared to existing temporal graph models. We believe that these findings open up opportunities for future research on temporal graphs. Finally, TGB provides an automated machine learning pipeline for reproducible and accessible temporal graph research, including data loading, experiment setup and performance evaluation. TGB will be maintained and updated on a regular basis and welcomes community feedback. TGB datasets, data loaders, example codes, evaluation setup, and leaderboards are publicly available at this https URL.}
 }
@@ -242,6 +256,7 @@
   blog        = {/blog/2023/dirgnn/},
   preview     = {dir-gnn.png},
   pubtype     = {conference},
+  topics      = {graphs},
   bibtex_show = {true},
   abstract    = {Graph Neural Networks (GNNs) have become the de-facto standard tool for modeling relational data. However, while many real-world graphs are directed, the majority of today's GNN models discard this information altogether by simply making the graph undirected. The reasons for this are historical: 1) many early variants of spectral GNNs explicitly required undirected graphs, and 2) the first benchmarks on homophilic graphs did not find significant gain from using direction. In this paper, we show that in heterophilic settings, treating the graph as directed increases the effective homophily of the graph, suggesting a potential gain from the correct use of directionality information. To this end, we introduce Directed Graph Neural Network (Dir-GNN), a novel general framework for deep learning on directed graphs. Dir-GNN can be used to extend any Message Passing Neural Network (MPNN) to account for edge directionality information by performing separate aggregations of the incoming and outgoing edges. We prove that Dir-GNN matches the expressivity of the Directed Weisfeiler-Lehman test, exceeding that of conventional MPNNs. In extensive experiments, we validate that while our framework leaves performance unchanged on homophilic datasets, it leads to large gains over base models such as GCN, GAT and GraphSage on heterophilic benchmarks, outperforming much more complex methods and achieving new state-of-the-art results.}
 }
@@ -258,6 +273,7 @@
   preview     = {lp.png},
   video       = {https://www.youtube.com/watch?v=TPqR1xG9wgY},
   pubtype     = {conference},
+  topics      = {graphs},
   bibtex_show = {true},
   abstract    = {Many Graph Neural Networks (GNNs) perform poorly compared to simple heuristics on Link Prediction (LP) tasks. This is due to limitations in expressive power such as the inability to count triangles (the backbone of most LP heuristics) and because they can not distinguish automorphic nodes (those having identical structural roles). Both expressiveness issues can be alleviated by learning link (rather than node) representations and incorporating structural features such as triangle counts. Since explicit link representations are often prohibitively expensive, recent works resorted to subgraph-based methods, which have achieved state-of-the-art performance for LP, but suffer from poor efficiency due to high levels of redundancy between subgraphs. We analyze the components of subgraph GNN (SGNN) methods for link prediction. Based on our analysis, we propose a novel full-graph GNN called ELPH (Efficient Link Prediction with Hashing) that passes subgraph sketches as messages to approximate the key components of SGNNs without explicit subgraph construction. ELPH is provably more expressive than Message Passing GNNs (MPNNs). It outperforms existing SGNN models on many standard LP benchmarks while being orders of magnitude faster. However, it shares the common GNN limitation that it is only efficient when the dataset fits in GPU memory. Accordingly, we develop a highly scalable model, called BUDDY, which uses feature precomputation to circumvent this limitation without sacrificing predictive performance. Our experiments show that BUDDY also outperforms SGNNs on standard LP benchmarks while being highly scalable and faster than ELPH.},
   award       = {Oral (top 5%)}
@@ -289,6 +305,7 @@
   blog        = {/blog/2023/network_games/},
   preview     = {network_games.webp},
   pubtype     = {conference},
+  topics      = {graphs},
   bibtex_show = {true},
   abstract    = {Strategic interactions between a group of individuals or organisations can be modelled as games played on networks, where a player's payoff depends not only on their actions but also on those of their neighbours. Inferring the network structure from observed game outcomes (equilibrium actions) is an important problem with numerous potential applications in economics and social sciences. Existing methods mostly require the knowledge of the utility function associated with the game, which is often unrealistic to obtain in real-world scenarios. We adopt a transformer-like architecture which correctly accounts for the symmetries of the problem and learns a mapping from the equilibrium actions to the network structure of the game without explicit knowledge of the utility function. We test our method on three different types of network games using both synthetic and real-world data, and demonstrate its effectiveness in network structure inference and superior performance over existing methods.}
 }
@@ -306,6 +323,7 @@
   blog        = {https://towardsdatascience.com/learning-on-graphs-with-missing-features-dd34be61b06},
   preview     = {fp.gif},
   pubtype     = {conference},
+  topics      = {graphs},
   bibtex_show = {true},
   abstract    = {While Graph Neural Networks (GNNs) have recently become the de facto standard for modeling relational data, they impose a strong assumption on the availability of the node or edge features of the graph. In many real-world applications, however, features are only partially available; for example, in social networks, age and gender are available only for a small subset of users. We present a general approach for handling missing features in graph machine learning applications that is based on minimization of the Dirichlet energy and leads to a diffusion-type differential equation on the graph. The discretization of this equation produces a simple, fast and scalable algorithm which we call Feature Propagation. We experimentally show that the proposed approach outperforms previous methods on seven common node-classification benchmarks and can withstand surprisingly high rates of missing features: on average we observe only around 4% relative accuracy drop when 99% of the features are missing. Moreover, it takes only 10 seconds to run on a graph with ∼2.5M nodes and ∼123M edges on a single GPU.}
 }
@@ -323,6 +341,7 @@
   blog        = {https://blog.twitter.com/engineering/en_us/topics/insights/2021/graph-neural-networks-as-neural-diffusion-pdes},
   preview     = {grand.png},
   pubtype     = {conference},
+  topics      = {graphs},
   bibtex_show = {true},
   abstract    = {We present Graph Neural Diffusion (GRAND) that approaches deep learning on graphs as a continuous diffusion process and treats Graph Neural Networks (GNNs) as discretisations of an underlying PDE. In our model, the layer structure and topology correspond to the discretisation choices of temporal and spatial operators. Our approach allows a principled development of a broad new class of GNNs that are able to address the common plights of graph learning models such as depth, oversmoothing, and bottlenecks. Key to the success of our models are stability with respect to perturbations in the data and this is addressed for both implicit and explicit discretisation schemes. We develop linear and nonlinear versions of GRAND, which achieve competitive results on many standard graph benchmarks.}
 }
@@ -355,6 +374,7 @@
   selected    = {true},
   preview     = {tgn.png},
   pubtype     = {workshop},
+  topics      = {graphs},
   bibtex_show = {true},
   proceedings = {https://icml.cc/virtual/2020/7729},
   abstract    = {Graph Neural Networks (GNNs) have recently become increasingly popular due to their ability to learn complex systems of relations or interactions arising in a broad spectrum of problems ranging from biology and particle physics to social networks and recommendation systems. Despite the plethora of different models for deep learning on graphs, few approaches have been proposed thus far for dealing with graphs that present some sort of dynamic nature (e.g. evolving features or connectivity over time). In this paper, we present Temporal Graph Networks (TGNs), a generic, efficient framework for deep learning on dynamic graphs represented as sequences of timed events. Thanks to a novel combination of memory modules and graph-based operators, TGNs are able to significantly outperform previous approaches being at the same time more computationally efficient. We furthermore show that several previous models for learning on dynamic graphs can be cast as specific instances of our framework. We perform a detailed ablation study of different components of our framework and devise the best configuration that achieves state-of-the-art performance on several transductive and inductive prediction tasks for dynamic graphs.}
@@ -372,6 +392,7 @@
   selected    = {false},
   preview     = {sign.png},
   pubtype     = {workshop},
+  topics      = {graphs},
   bibtex_show = {true},
   proceedings = {https://icml.cc/virtual/2020/7734},
   abstract    = {Graph representation learning has recently been applied to a broad spectrum of problems ranging from computer graphics and chemistry to high energy physics and social media. The popularity of graph neural networks has sparked interest, both in academia and in industry, in developing methods that scale to very large graphs such as Facebook or Twitter social networks. In most of these approaches, the computational cost is alleviated by a sampling strategy retaining a subset of node neighbors or subgraphs at training time. In this paper we propose a new, efficient and scalable graph deep learning architecture which sidesteps the need for graph sampling by using graph convolutional filters of different size that are amenable to efficient precomputation, allowing extremely fast training and inference. Our architecture allows using different local graph operators (e.g. motif-induced adjacency matrices or Personalized Page Rank diffusion matrix) to best suit the task at hand. We conduct extensive experimental evaluation on various open benchmarks and show that our approach is competitive with other state-of-the-art architectures, while requiring a fraction of the training and inference time. Moreover, we obtain state-of-the-art results on ogbn-papers100M, the largest public graph dataset, with over 110 million nodes and 1.5 billion edges.}
@@ -387,6 +408,7 @@
   code        = {https://github.com/emalgorithm/ncRNA-family-prediction},
   preview     = {rna.png},
   pubtype     = {workshop},
+  topics      = {graphs, molecular-biology},
   bibtex_show = {true},
   proceedings = {https://deep-learning-graphs.bitbucket.io/dlg-kdd19/accepted_papers/DLG_2019_paper_17.pdf},
   abstract    = {Non-coding RNA (ncRNA) are RNA sequences which don't code for a gene but instead carry important biological functions. The task of ncRNA classification consists in classifying a given ncRNA sequence into its family. While it has been shown that the graph structure of an ncRNA sequence folding is of great importance for the prediction of its family, current methods make use of machine learning classifiers on hand-crafted graph features. We improve on the state-of-the-art for this task with a graph convolutional network model which achieves an accuracy of 85.73% and an F1-score of 85.61% over 13 classes. Moreover, our model learns in an end-to-end fashion from the raw RNA graphs and removes the need for expensive feature extraction. To the best of our knowledge, this also represents the first successful application of graph convolutional networks to RNA folding data.}

--- a/_config.yml
+++ b/_config.yml
@@ -413,6 +413,7 @@ filtered_bibtex_keywords:
     selected,
     slides,
     supp,
+    topics,
     video,
     website,
     xthread,

--- a/_data/topics.yml
+++ b/_data/topics.yml
@@ -1,0 +1,7 @@
+# Publication topic filters: slug -> display label.
+# The slug must match the `topics` field used in _bibliography/papers.bib.
+# Do not use `all` as a slug here — it is reserved for the "All" button.
+animal-communication: ML x Animal Communication
+graphs: ML x Graphs
+lightning-network: ML x Lightning Network
+molecular-biology: ML x Molecular Biology

--- a/_includes/bib_search.liquid
+++ b/_includes/bib_search.liquid
@@ -12,10 +12,9 @@
     >
     <div class="publication-topic-filters" role="group" aria-label="Filter publications by topic">
       <button type="button" class="publication-topic-filter active" data-topic="all" aria-pressed="true">All</button>
-      <button type="button" class="publication-topic-filter" data-topic="animal-communication" aria-pressed="false">ML x Animal Communication</button>
-      <button type="button" class="publication-topic-filter" data-topic="graphs" aria-pressed="false">ML x Graphs</button>
-      <button type="button" class="publication-topic-filter" data-topic="lightning-network" aria-pressed="false">ML x Lightning Network</button>
-      <button type="button" class="publication-topic-filter" data-topic="molecular-biology" aria-pressed="false">ML x Molecular Biology</button>
+      {% for topic in site.data.topics %}
+        <button type="button" class="publication-topic-filter" data-topic="{{ topic[0] }}" aria-pressed="false">{{ topic[1] }}</button>
+      {% endfor %}
     </div>
   </div>
 {% endif %}

--- a/_includes/bib_search.liquid
+++ b/_includes/bib_search.liquid
@@ -1,4 +1,21 @@
 {% if site.bib_search %}
   <script src="{{ '/assets/js/bibsearch.js' | relative_url | bust_file_cache }}" type="module"></script>
-  <input type="text" id="bibsearch" spellcheck="false" autocomplete="off" class="search bibsearch-form-input" placeholder="Type to filter">
+  <div class="publication-filters" aria-label="Publication filters">
+    <input
+      type="text"
+      id="bibsearch"
+      spellcheck="false"
+      autocomplete="off"
+      class="search bibsearch-form-input"
+      placeholder="Type to filter"
+      aria-label="Search publications"
+    >
+    <div class="publication-topic-filters" role="group" aria-label="Filter publications by topic">
+      <button type="button" class="publication-topic-filter active" data-topic="all" aria-pressed="true">All</button>
+      <button type="button" class="publication-topic-filter" data-topic="animal-communication" aria-pressed="false">ML x Animal Communication</button>
+      <button type="button" class="publication-topic-filter" data-topic="graphs" aria-pressed="false">ML x Graphs</button>
+      <button type="button" class="publication-topic-filter" data-topic="lightning-network" aria-pressed="false">ML x Lightning Network</button>
+      <button type="button" class="publication-topic-filter" data-topic="molecular-biology" aria-pressed="false">ML x Molecular Biology</button>
+    </div>
+  </div>
 {% endif %}

--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -69,7 +69,11 @@
   {% endif %}
 
   <!-- Entry bib key -->
-  <div id="{{ entry.key }}" class="{% if site.enable_publication_thumbnails %}col-sm-8{% else %}col-sm-10{% endif %}">
+  <div
+    id="{{ entry.key }}"
+    class="{% if site.enable_publication_thumbnails %}col-sm-8{% else %}col-sm-10{% endif %}"
+    data-topics="{{ entry.topics | default: '' | remove: ' ' | split: ',' | join: ' ' | escape }}"
+  >
     <!-- Title -->
     <div class="title">{{ entry.title }}</div>
     <!-- Author -->

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -49,14 +49,14 @@ $badge-default-hue: #546e7a;
 }
 
 .publication-topic-filter {
-  background-color: transparent;
+  background-color: color-mix(in srgb, var(--global-text-color) 4%, transparent);
   color: var(--global-text-color);
   border: 1px solid var(--global-divider-color);
-  border-radius: 6px;
+  border-radius: 999px;
   cursor: pointer;
   font-size: 0.95rem;
   line-height: 1.2;
-  padding: 0.42rem 0.75rem;
+  padding: 0.4rem 0.9rem;
   transition:
     background-color 0.15s ease,
     border-color 0.15s ease,
@@ -64,6 +64,7 @@ $badge-default-hue: #546e7a;
 
   &:hover,
   &:focus {
+    background-color: color-mix(in srgb, var(--global-theme-color) 10%, transparent);
     color: var(--global-theme-color);
     border-color: var(--global-theme-color);
     outline: none;

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -70,9 +70,7 @@ $badge-default-hue: #546e7a;
   }
 
   &.active {
-    background-color: color-mix(in srgb, var(--global-theme-color) 16%, white);
-    color: color-mix(in srgb, var(--global-theme-color) 85%, black);
-    border-color: color-mix(in srgb, var(--global-theme-color) 32%, white);
+    @include soft-badge(var(--global-theme-color));
   }
 }
 
@@ -140,9 +138,7 @@ $badge-default-hue: #546e7a;
 html[data-theme="dark"] {
   .publication-topic-filter {
     &.active {
-      background-color: color-mix(in srgb, var(--global-theme-color) 35%, var(--global-card-bg-color));
-      color: color-mix(in srgb, var(--global-theme-color) 40%, white);
-      border-color: color-mix(in srgb, var(--global-theme-color) 55%, var(--global-card-bg-color));
+      @include soft-badge-dark(var(--global-theme-color));
     }
   }
 

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -30,6 +30,52 @@ $badge-default-hue: #546e7a;
   border-color: color-mix(in srgb, #{$hue} 55%, var(--global-card-bg-color)) !important;
 }
 
+// Publication topic filters
+.publication-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.95rem;
+  margin: 1.5rem 0 0.5rem;
+
+  .bibsearch-form-input {
+    margin-right: 0;
+  }
+}
+
+.publication-topic-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.publication-topic-filter {
+  background-color: transparent;
+  color: var(--global-text-color);
+  border: 1px solid var(--global-divider-color);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  line-height: 1.2;
+  padding: 0.42rem 0.75rem;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+
+  &:hover,
+  &:focus {
+    color: var(--global-theme-color);
+    border-color: var(--global-theme-color);
+    outline: none;
+  }
+
+  &.active {
+    background-color: color-mix(in srgb, var(--global-theme-color) 16%, white);
+    color: color-mix(in srgb, var(--global-theme-color) 85%, black);
+    border-color: color-mix(in srgb, var(--global-theme-color) 32%, white);
+  }
+}
+
 // Publication Type Badges
 // !important needed on all color properties to override mdbootstrap's .badge { color/bg: !important }
 .pubtype-tags {
@@ -92,6 +138,14 @@ $badge-default-hue: #546e7a;
 
 // Dark mode overrides for all publication badges
 html[data-theme="dark"] {
+  .publication-topic-filter {
+    &.active {
+      background-color: color-mix(in srgb, var(--global-theme-color) 35%, var(--global-card-bg-color));
+      color: color-mix(in srgb, var(--global-theme-color) 40%, white);
+      border-color: color-mix(in srgb, var(--global-theme-color) 55%, var(--global-card-bg-color));
+    }
+  }
+
   .pubtype-tags {
     .badge-conference {
       @include soft-badge-dark($badge-conference-hue);

--- a/assets/js/bibsearch.js
+++ b/assets/js/bibsearch.js
@@ -1,30 +1,88 @@
 import { highlightSearchTerm } from "./highlight-search-term.js";
 
 document.addEventListener("DOMContentLoaded", function () {
-  // actual bibsearch logic
-  const filterItems = (searchTerm) => {
-    document.querySelectorAll(".bibliography, .unloaded").forEach((element) => element.classList.remove("unloaded"));
+  const selectors = {
+    entry: ".bibliography > li",
+    groupHeading: "h2.bibliography",
+    searchInput: "bibsearch",
+    topicButton: ".publication-topic-filter",
+    topicMetadata: "[data-topics]",
+  };
+  const params = {
+    search: "q",
+    topic: "topic",
+  };
+  const allTopic = "all";
+  const searchInput = document.getElementById(selectors.searchInput);
+  const topicButtons = Array.from(document.querySelectorAll(selectors.topicButton));
+  let activeTopic = "all";
 
-    // highlight-search-term
-    if (CSS.highlights) {
-      const nonMatchingElements = highlightSearchTerm({ search: searchTerm, selector: ".bibliography > li" });
-      if (nonMatchingElements == null) {
-        return;
-      }
-      nonMatchingElements.forEach((element) => {
-        element.classList.add("unloaded");
-      });
+  if (!searchInput) {
+    return;
+  }
+
+  const entryTopics = (entry) => {
+    const topicElement = entry.querySelector(selectors.topicMetadata);
+    const topics = topicElement ? topicElement.dataset.topics : "";
+    return topics.split(/[,\s]+/).filter(Boolean);
+  };
+
+  const setActiveTopic = (topic) => {
+    const matchingButton = topicButtons.find((button) => button.dataset.topic === topic);
+    activeTopic = matchingButton ? topic : allTopic;
+
+    topicButtons.forEach((topicButton) => {
+      const isActive = topicButton.dataset.topic === activeTopic;
+      topicButton.classList.toggle("active", isActive);
+      topicButton.setAttribute("aria-pressed", isActive.toString());
+    });
+  };
+
+  const syncUrl = ({ replace = false } = {}) => {
+    const url = new URL(window.location.href);
+    const trimmedSearchTerm = searchInput.value.trim();
+
+    if (trimmedSearchTerm) {
+      url.searchParams.set(params.search, trimmedSearchTerm);
     } else {
-      // Simply add unloaded class to all non-matching items if Browser does not support CSS highlights
-      document.querySelectorAll(".bibliography > li").forEach((element, index) => {
-        const text = element.innerText.toLowerCase();
-        if (text.indexOf(searchTerm) == -1) {
-          element.classList.add("unloaded");
-        }
-      });
+      url.searchParams.delete(params.search);
     }
 
-    document.querySelectorAll("h2.bibliography").forEach(function (element) {
+    if (activeTopic === allTopic) {
+      url.searchParams.delete(params.topic);
+    } else {
+      url.searchParams.set(params.topic, activeTopic);
+    }
+
+    if (url.hash) {
+      const hashValue = decodeURIComponent(url.hash.substring(1));
+      if (hashValue && !document.getElementById(hashValue)) {
+        url.hash = "";
+      }
+    }
+
+    const method = replace ? "replaceState" : "pushState";
+    window.history[method]({}, "", url);
+  };
+
+  const getSearchTermFromUrl = () => {
+    const querySearchTerm = new URLSearchParams(window.location.search).get(params.search);
+    if (querySearchTerm !== null) {
+      return querySearchTerm;
+    }
+
+    const hashValue = decodeURIComponent(window.location.hash.substring(1)); // Remove the '#' character
+    return hashValue && !document.getElementById(hashValue) ? hashValue : "";
+  };
+
+  const setStateFromUrl = () => {
+    const urlParams = new URLSearchParams(window.location.search);
+    setActiveTopic(urlParams.get(params.topic) || allTopic);
+    searchInput.value = getSearchTermFromUrl();
+  };
+
+  const hideEmptyGroups = () => {
+    document.querySelectorAll(selectors.groupHeading).forEach(function (element) {
       let iterator = element.nextElementSibling; // get next sibling element after h2, which can be h3 or ol
       let hideFirstGroupingElement = true;
       // iterate until next group element (h2), which is already selected by the querySelectorAll(-).forEach(-)
@@ -50,21 +108,60 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   };
 
-  const updateInputField = () => {
-    const hashValue = decodeURIComponent(window.location.hash.substring(1)); // Remove the '#' character
-    document.getElementById("bibsearch").value = hashValue;
-    filterItems(hashValue);
+  const applyFilters = () => {
+    const searchTerm = searchInput.value.toLowerCase();
+    document.querySelectorAll(".bibliography, .unloaded").forEach((element) => element.classList.remove("unloaded"));
+
+    let nonMatchingSearchElements = new Set();
+
+    if (CSS.highlights) {
+      const nonMatchingElements = highlightSearchTerm({ search: searchTerm, selector: selectors.entry });
+      if (nonMatchingElements) {
+        nonMatchingSearchElements = new Set(nonMatchingElements);
+      }
+    }
+
+    document.querySelectorAll(selectors.entry).forEach((element) => {
+      const topics = entryTopics(element);
+      const matchesTopic = activeTopic === allTopic || topics.includes(activeTopic);
+      const text = element.innerText.toLowerCase();
+      const matchesSearch = searchTerm === "" || (CSS.highlights ? !nonMatchingSearchElements.has(element) : text.includes(searchTerm));
+
+      if (!matchesTopic || !matchesSearch) {
+        element.classList.add("unloaded");
+      }
+    });
+
+    hideEmptyGroups();
   };
 
   // Sensitive search. Only start searching if there's been no input for 300 ms
   let timeoutId;
-  document.getElementById("bibsearch").addEventListener("input", function () {
+  searchInput.addEventListener("input", function () {
     clearTimeout(timeoutId); // Clear the previous timeout
-    const searchTerm = this.value.toLowerCase();
-    timeoutId = setTimeout(filterItems(searchTerm), 300);
+    timeoutId = setTimeout(() => {
+      syncUrl({ replace: true });
+      applyFilters();
+    }, 300);
   });
 
-  window.addEventListener("hashchange", updateInputField); // Update the filter when the hash changes
+  topicButtons.forEach((button) => {
+    button.addEventListener("click", function () {
+      setActiveTopic(this.dataset.topic || allTopic);
+      syncUrl();
+      applyFilters();
+    });
+  });
 
-  updateInputField(); // Update filter when page loads
+  window.addEventListener("hashchange", function () {
+    setStateFromUrl();
+    applyFilters();
+  });
+  window.addEventListener("popstate", function () {
+    setStateFromUrl();
+    applyFilters();
+  });
+
+  setStateFromUrl();
+  applyFilters();
 });

--- a/assets/js/bibsearch.js
+++ b/assets/js/bibsearch.js
@@ -15,17 +15,21 @@ document.addEventListener("DOMContentLoaded", function () {
   const allTopic = "all";
   const searchInput = document.getElementById(selectors.searchInput);
   const topicButtons = Array.from(document.querySelectorAll(selectors.topicButton));
-  let activeTopic = "all";
+  let activeTopic = allTopic;
 
   if (!searchInput) {
     return;
   }
 
-  const entryTopics = (entry) => {
-    const topicElement = entry.querySelector(selectors.topicMetadata);
-    const topics = topicElement ? topicElement.dataset.topics : "";
-    return topics.split(/[,\s]+/).filter(Boolean);
-  };
+  // Entries and their topics are static for the page lifetime, so resolve them once.
+  const entries = Array.from(document.querySelectorAll(selectors.entry));
+  const entryTopics = new Map(
+    entries.map((entry) => {
+      const topicElement = entry.querySelector(selectors.topicMetadata);
+      const topics = topicElement ? topicElement.dataset.topics : "";
+      return [entry, topics.split(/[,\s]+/).filter(Boolean)];
+    })
+  );
 
   const setActiveTopic = (topic) => {
     const matchingButton = topicButtons.find((button) => button.dataset.topic === topic);
@@ -65,20 +69,19 @@ document.addEventListener("DOMContentLoaded", function () {
     window.history[method]({}, "", url);
   };
 
-  const getSearchTermFromUrl = () => {
-    const querySearchTerm = new URLSearchParams(window.location.search).get(params.search);
-    if (querySearchTerm !== null) {
-      return querySearchTerm;
-    }
-
-    const hashValue = decodeURIComponent(window.location.hash.substring(1)); // Remove the '#' character
-    return hashValue && !document.getElementById(hashValue) ? hashValue : "";
-  };
-
   const setStateFromUrl = () => {
     const urlParams = new URLSearchParams(window.location.search);
     setActiveTopic(urlParams.get(params.topic) || allTopic);
-    searchInput.value = getSearchTermFromUrl();
+
+    const querySearchTerm = urlParams.get(params.search);
+    if (querySearchTerm !== null) {
+      searchInput.value = querySearchTerm;
+    } else {
+      // Backward-compat with upstream al-folio: a hash that isn't a real entry
+      // anchor (e.g. #graph) is treated as a search term; real #bibkey anchors scroll.
+      const hashValue = decodeURIComponent(window.location.hash.substring(1));
+      searchInput.value = hashValue && !document.getElementById(hashValue) ? hashValue : "";
+    }
   };
 
   const hideEmptyGroups = () => {
@@ -121,11 +124,10 @@ document.addEventListener("DOMContentLoaded", function () {
       }
     }
 
-    document.querySelectorAll(selectors.entry).forEach((element) => {
-      const topics = entryTopics(element);
-      const matchesTopic = activeTopic === allTopic || topics.includes(activeTopic);
-      const text = element.innerText.toLowerCase();
-      const matchesSearch = searchTerm === "" || (CSS.highlights ? !nonMatchingSearchElements.has(element) : text.includes(searchTerm));
+    entries.forEach((element) => {
+      const matchesTopic = activeTopic === allTopic || entryTopics.get(element).includes(activeTopic);
+      const matchesSearch =
+        searchTerm === "" || (CSS.highlights ? !nonMatchingSearchElements.has(element) : element.textContent.toLowerCase().includes(searchTerm));
 
       if (!matchesTopic || !matchesSearch) {
         element.classList.add("unloaded");
@@ -153,15 +155,15 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   });
 
-  window.addEventListener("hashchange", function () {
+  const syncFromUrl = () => {
     setStateFromUrl();
     applyFilters();
-  });
-  window.addEventListener("popstate", function () {
-    setStateFromUrl();
-    applyFilters();
-  });
+  };
 
-  setStateFromUrl();
-  applyFilters();
+  window.addEventListener("hashchange", syncFromUrl);
+  window.addEventListener("popstate", syncFromUrl);
+
+  syncFromUrl();
+  // Canonicalize the address bar on load (e.g. drop an unknown ?topic=) without adding history.
+  syncUrl({ replace: true });
 });


### PR DESCRIPTION
## Summary
- add publication topic metadata and client-side topic filters to the publications page
- support shareable `topic` and `q` URL parameters for filtered publication views
- hide the internal `topics` BibTeX field from the displayed Bib output

## Validation
- `npx prettier --check --ignore-unknown _config.yml _pages/publications.md _includes/bib_search.liquid _layouts/bib.liquid assets/js/bibsearch.js _sass/_custom.scss _bibliography/papers.bib`
- `git diff --check`
- local Docker/Jekyll render at `http://localhost:8080/publications/`
- browser smoke checks for topic filters, combined topic/search URLs, and hidden BibTeX topics field
