### PR TITLE
Fix expandable compact publication authors

### DIFF
--- a/.al-folio-overrides.yml
+++ b/.al-folio-overrides.yml
@@ -27,8 +27,8 @@ overrides:
     gem_version: 1.0.11
     upstream_path: _layouts/bib.liquid
     upstream_sha256: 430311d9b94adf6fb1c2fab7609f6e726efc98e2b50e7b1c4cde0ad654c04506
-    local_sha256: a800c63312b3676c9eb7959049e51b1bf30042d51899dac0795f331a7f59b3dd
-    acknowledged_at: "2026-06-04"
+    local_sha256: e2464ecf6a9e32235489baa008882d6595803bca9b8be21875701c91047c382d
+    acknowledged_at: "2026-06-05"
   assets/css/main.scss:
     owner: al_folio_core
     gem_version: 1.0.11

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Site-specific instructions are in [LOCAL_AGENTS.md](LOCAL_AGENTS.md).
+
 @AGENTS.md
 
 The import above (`AGENTS.md`, which itself defers to `.github/copilot-instructions.md` and `docs/BOUNDARIES.md`) is the canonical short entry point: ownership boundaries, the validated command set, and PR-routing rules. Keep `AGENTS.md` short and ecosystem-neutral — put Claude-specific or longer-form guidance here instead. Everything below is the cross-repo "big picture" that those files assume but don't spell out.

--- a/_config.yml
+++ b/_config.yml
@@ -485,9 +485,10 @@ filtered_bibtex_keywords:
     xthread,
   ]
 
-# Maximum number of authors to be shown for each publication (more authors are visible on click)
-max_author_limit: 3 # leave blank to always show all authors
-more_authors_animation_delay: 10 # more authors are revealed on click using animation; smaller delay means faster animation
+# Maximum number of leading authors shown in the compact view (the last author and your own
+# name are always shown too; the full list is revealed by clicking the ellipsis). Leave blank
+# to always show all authors.
+max_author_limit: 2
 
 # Enables publication thumbnails. If disabled, none of the publications will display thumbnails, even if specified in the bib entry.
 enable_publication_thumbnails: true

--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -77,91 +77,153 @@
     <div class="title">{{ entry.title }}</div>
     <!-- Author -->
     <div class="author">
-      {% assign author_array_size = entry.author_array | size %}
+      {%- assign author_array_size = entry.author_array | size -%}
+      {%- assign last_index = author_array_size | minus: 1 -%}
 
-      {% assign author_array_limit = author_array_size %}
-      {% if site.max_author_limit and author_array_size > site.max_author_limit %}
-        {% assign author_array_limit = site.max_author_limit %}
-      {% endif %}
+      {%- assign author_array_limit = author_array_size -%}
+      {%- if site.max_author_limit and author_array_size > site.max_author_limit -%}
+        {%- assign author_array_limit = site.max_author_limit -%}
+      {%- endif -%}
 
-      {%- for author in entry.author_array limit: author_array_limit -%}
-        {% assign author_is_self = false %}
-        {%- assign author_last_name = author.last | regex_replace: '[*∗†‡§¶‖&^]', '' -%}
-        {%- assign author_last_html = author.last | regex_replace: '([*∗†‡§¶‖&^]+)', '<sup>\1</sup>' -%}
-        {% if site.scholar.last_name contains author_last_name %}
-          {% if site.scholar.first_name contains author.first %}
-            {% assign author_is_self = true %}
-          {% endif %}
+      {%- comment -%}
+        Compact view shows the first authors (up to author_array_limit), the final author,
+        and the site owner ("self") — collapsing any gaps to a clickable ellipsis. Locate
+        self first so the owner's name is never hidden. A second, hidden span holds the full
+        author list; the ellipsis / "show less" toggles between the two.
+      {%- endcomment -%}
+      {%- assign self_index = -1 -%}
+      {%- for author in entry.author_array -%}
+        {%- assign self_last_name = author.last | regex_replace: '[*∗†‡§¶‖&^]', '' -%}
+        {%- if site.scholar.last_name contains self_last_name and site.scholar.first_name contains author.first -%}
+          {%- assign self_index = forloop.index0 -%}
+          {%- break -%}
         {%- endif -%}
-        {% assign coauthor_url = null %}
-        {%- assign clean_last_name = author_last_name | downcase | remove_accents -%}
-        {% if site.data.coauthors[clean_last_name] %}
-          {%- for coauthor in site.data.coauthors[clean_last_name] -%}
-            {% if coauthor.firstname contains author.first %}
-              {%- assign coauthor_url = coauthor.url -%}
-              {% break %}
+      {%- endfor -%}
+
+      {%- comment -%} Count authors hidden by the compact view (everyone but the first N, self, and the last author). {%- endcomment -%}
+      {%- assign hidden_count = 0 -%}
+      {%- for author in entry.author_array -%}
+        {%- assign author_index = forloop.index0 -%}
+        {%- assign shown = false -%}
+        {%- if author_index < author_array_limit %}{% assign shown = true %}{% endif -%}
+        {%- if author_index == self_index %}{% assign shown = true %}{% endif -%}
+        {%- if author_index == last_index %}{% assign shown = true %}{% endif -%}
+        {%- unless shown %}{% assign hidden_count = hidden_count | plus: 1 %}{% endunless -%}
+      {%- endfor -%}
+
+      {%- comment -%} ===== Compact author list ===== {%- endcomment -%}
+      <span class="authors-compact">
+        {%- assign last_shown_index = -1 -%}
+        {%- for author in entry.author_array -%}
+          {%- assign author_index = forloop.index0 -%}
+          {%- assign show_author = false -%}
+          {%- if author_index < author_array_limit %}{% assign show_author = true %}{% endif -%}
+          {%- if author_index == self_index %}{% assign show_author = true %}{% endif -%}
+          {%- if author_index == last_index %}{% assign show_author = true %}{% endif -%}
+          {%- if show_author -%}
+            {%- assign author_is_self = false -%}
+            {%- if author_index == self_index %}{% assign author_is_self = true %}{% endif -%}
+            {%- assign author_last_name = author.last | regex_replace: '[*∗†‡§¶‖&^]', '' -%}
+            {%- assign author_last_html = author.last | regex_replace: '([*∗†‡§¶‖&^]+)', '<sup>\1</sup>' -%}
+            {%- assign coauthor_url = null -%}
+            {%- assign clean_last_name = author_last_name | downcase | remove_accents -%}
+            {%- if site.data.coauthors[clean_last_name] -%}
+              {%- for coauthor in site.data.coauthors[clean_last_name] -%}
+                {%- if coauthor.firstname contains author.first -%}
+                  {%- assign coauthor_url = coauthor.url -%}
+                  {%- break -%}
+                {%- endif -%}
+              {%- endfor -%}
             {%- endif -%}
-          {% endfor %}
-        {%- endif -%}
-
-        {%- if forloop.length > 1 -%}
-          {% if forloop.first == false -%}
-            {%- if forloop.length > 2 %}, {% elsif forloop.length == 2 %}  {% endif %}
-          {%- endif %}
-          {%- if forloop.last and author_array_limit == author_array_size %}and {% endif -%}
-        {% endif %}
-        {%- if author_is_self -%}
-          <em>
-            {{- author.first }}
-            {{ author_last_html -}}
-          </em>
-        {%- else -%}
-          {%- if coauthor_url -%}
-            <a href="{{ coauthor_url }}">
-              {{- author.first }}
-              {{ author_last_html -}}
-            </a>
-          {%- else -%}
-            {{- author.first }}
-            {{ author_last_html -}}
-          {% endif %}
-        {%- endif -%}
-      {% endfor %}
-      {%- assign more_authors = author_array_size | minus: author_array_limit -%}
-
-      {%- assign more_authors_hide = more_authors | append: ' more author' -%}
-      {% if more_authors > 0 %}
-        {%- if more_authors > 1 -%}
-          {% assign more_authors_hide = more_authors_hide | append: 's' %}
-        {%- endif -%}
-        {% assign more_authors_show = '' %}
-        {%- for author in entry.author_array offset: author_array_limit -%}
-          {% assign more_authors_show = more_authors_show | append: author.first | append: ' ' | append: author.last %}
-          {% unless forloop.last %}
-            {% assign more_authors_show = more_authors_show | append: ', ' %}
-          {% endunless %}
+            {%- comment -%} Separator: clickable ellipsis when authors were skipped, otherwise the normal comma/"and". {%- endcomment -%}
+            {%- if last_shown_index >= 0 -%}
+              {%- assign contiguous_index = last_shown_index | plus: 1 -%}
+              {%- if author_index > contiguous_index -%}
+                {{ ', ' -}}
+                <span
+                  class="more-authors"
+                  role="button"
+                  tabindex="0"
+                  title="Show all authors"
+                  onclick="var a = this.closest('.author'); a.querySelector('.authors-compact').style.display = 'none'; a.querySelector('.authors-full').style.display = 'inline';"
+                  onkeydown="if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); this.click(); }"
+                  >…</span
+                >
+                {{- ', ' }}
+              {%- else -%}
+                {%- if author_array_size > 2 %}, {% elsif author_array_size == 2 %}  {% endif -%}
+                {%- if forloop.last and hidden_count == 0 %}and {% endif -%}
+              {%- endif -%}
+            {%- endif -%}
+            {%- if author_is_self -%}
+              <em>
+                {{- author.first }}
+                {{ author_last_html -}}
+              </em>
+            {%- elsif coauthor_url -%}
+              <a href="{{ coauthor_url }}">
+                {{- author.first }}
+                {{ author_last_html -}}
+              </a>
+            {%- else -%}
+              {{ author.first }}
+              {{ author_last_html }}
+            {%- endif -%}
+            {%- assign last_shown_index = author_index -%}
+          {%- endif -%}
         {%- endfor -%}
-        {%- assign more_authors_show = more_authors_show | regex_replace: '([*∗†‡§¶‖&^]+)', '<sup>\1</sup>' -%}
-        , and
-        <span
-          class="more-authors"
-          title="click to view {{ more_authors_hide }}"
-          onclick="
-              var element = this;
-              element.setAttribute('title', '');
-              var more_authors_text = element.textContent == '{{ more_authors_hide }}' ? '{{ more_authors_show }}' : '{{ more_authors_hide }}';
-              var cursorPosition = 0;
-              var textAdder = setInterval(function(){
-                element.innerHTML = more_authors_text.substring(0, cursorPosition + 1);
-                if (++cursorPosition == more_authors_text.length){
-                  clearInterval(textAdder);
-                }
-            }, '{{ site.more_authors_animation_delay }}');
-          "
-        >
-          {{- more_authors_hide -}}
+      </span>
+
+      {%- comment -%} ===== Full author list (hidden until expanded) ===== {%- endcomment -%}
+      {%- if hidden_count > 0 -%}
+        <span class="authors-full" style="display: none;">
+          {%- for author in entry.author_array -%}
+            {%- assign author_index = forloop.index0 -%}
+            {%- assign author_is_self = false -%}
+            {%- if author_index == self_index %}{% assign author_is_self = true %}{% endif -%}
+            {%- assign author_last_name = author.last | regex_replace: '[*∗†‡§¶‖&^]', '' -%}
+            {%- assign author_last_html = author.last | regex_replace: '([*∗†‡§¶‖&^]+)', '<sup>\1</sup>' -%}
+            {%- assign coauthor_url = null -%}
+            {%- assign clean_last_name = author_last_name | downcase | remove_accents -%}
+            {%- if site.data.coauthors[clean_last_name] -%}
+              {%- for coauthor in site.data.coauthors[clean_last_name] -%}
+                {%- if coauthor.firstname contains author.first -%}
+                  {%- assign coauthor_url = coauthor.url -%}
+                  {%- break -%}
+                {%- endif -%}
+              {%- endfor -%}
+            {%- endif -%}
+            {%- unless forloop.first -%}
+              {%- if author_array_size > 2 %}, {% elsif author_array_size == 2 %}  {% endif -%}
+              {%- if forloop.last %}and {% endif -%}
+            {%- endunless -%}
+            {%- if author_is_self -%}
+              <em>
+                {{- author.first }}
+                {{ author_last_html -}}
+              </em>
+            {%- elsif coauthor_url -%}
+              <a href="{{ coauthor_url }}">
+                {{- author.first }}
+                {{ author_last_html -}}
+              </a>
+            {%- else -%}
+              {{ author.first }}
+              {{ author_last_html }}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ ' ' -}}
+          <span
+            class="more-authors"
+            role="button"
+            tabindex="0"
+            title="Show fewer authors"
+            onclick="var a = this.closest('.author'); a.querySelector('.authors-full').style.display = 'none'; a.querySelector('.authors-compact').style.display = 'inline';"
+            onkeydown="if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); this.click(); }"
+            >[show less]</span
+          >
         </span>
-      {% endif %}
+      {%- endif -%}
       {% if entry.annotation %}
         <i
           class="fa-solid fa-circle-info ml-1"

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -75,6 +75,33 @@ $badge-default-hue: #546e7a;
   }
 }
 
+// The local compact/full author wrappers keep selected authors visible while
+// collapsing the middle of long lists. Mirror the core direct-child author
+// selectors for the nested markup.
+.publications ol.bibliography li .author {
+  .authors-compact > em,
+  .authors-full > em {
+    border-bottom: 1px solid;
+    font-style: normal;
+  }
+
+  .authors-compact > .more-authors,
+  .authors-full > .more-authors {
+    color: var(--global-text-color-light);
+    border-bottom: 1px dashed var(--global-text-color-light);
+    cursor: pointer;
+  }
+
+  .authors-compact > .more-authors:hover,
+  .authors-compact > .more-authors:focus,
+  .authors-full > .more-authors:hover,
+  .authors-full > .more-authors:focus {
+    color: var(--global-text-color);
+    border-bottom-color: var(--global-text-color);
+    outline: none;
+  }
+}
+
 // Publication Type Badges
 // !important needed on all color properties to override mdbootstrap's .badge { color/bg: !important }
 .pubtype-tags {


### PR DESCRIPTION
## Summary
- keep compact publication author lists expandable while always showing the site owner and final author
- restore the original self-name underline styling inside compact/full author wrappers
- use the previous grey (var(--global-text-color-light), #828282) for the dashed author toggle underline and [show less] text
- point CLAUDE.md to LOCAL_AGENTS.md for site-specific guidance

## Verification
- npm run lint:prettier
- docker compose exec -T jekyll bundle exec al-folio upgrade overrides audit
- Browser check on http://127.0.0.1:8080/publications/: compact ellipsis expands the full author list; Emanuele Rossi is underlined/non-italic; ellipsis and [show less] render in rgb(130, 130, 130) with dashed underline