### PR TITLE
chore: sync with upstream al-folio

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Feel free to add your own page(s) by sending a PR.
 <a href="https://martinbulla.github.io/bullab/" target="_blank">★</a>
 <a href="https://gpforesteyes.github.io/" target="_blank">★</a>
 <a href="https://kenji-fukushima-lab.github.io/" target="_blank">★</a>
+<a href="https://align.science/" target="_blank">★</a>
 </td>
 </tr>
 <tr>

--- a/_data/citations.yml
+++ b/_data/citations.yml
@@ -1,5 +1,5 @@
 metadata:
-  last_updated: '2026-06-22'
+  last_updated: '2026-07-06'
 papers:
   qc6CJjYAAAAJ:-1WLWRmjvKAC:
     citations: 4
@@ -18,7 +18,7 @@ papers:
     title: 'The Palestine Troubles: Einstein''s Protest, Zionism''s Basis and Achievement; the Mandatory''s Task'
     year: '1929'
   qc6CJjYAAAAJ:-LHtoeeytlUC:
-    citations: 2563
+    citations: 2574
     title: 'Albert Einstein: Philosopher Scientist'
     year: '1969'
   qc6CJjYAAAAJ:-R_Z4shfoosC:
@@ -26,11 +26,11 @@ papers:
     title: 'Albert Einstein] to Paul Ehrenfest: Letter, 22 Jul 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:-Viv1fr_sjoC:
-    citations: 139
+    citations: 138
     title: The special theory of relativity
     year: '1905'
   qc6CJjYAAAAJ:-_cDHGlXAtsC:
-    citations: 8494
+    citations: 8549
     title: Sitzungsberichte der Preussischen Akad. d
     year: '1917'
   qc6CJjYAAAAJ:-fj4grS0xi0C:
@@ -38,11 +38,11 @@ papers:
     title: 'Conceptions scientifiques, morales et sociales: traduit de l''anglais par Maurice Solovine'
     year: '1952'
   qc6CJjYAAAAJ:-l7FTdOV6Y0C:
-    citations: 194
+    citations: 193
     title: Brownian motion
     year: '1936'
   qc6CJjYAAAAJ:-qpA3cGbmHsC:
-    citations: 548
+    citations: 549
     title: On the Relation between the Expansion and the Mean Density of the Universe
     year: '1932'
   qc6CJjYAAAAJ:-vzq6BoH5oUC:
@@ -70,7 +70,7 @@ papers:
     title: Elementary Considerations on the Interpretation of the Foundations of Quantum Mechanics
     year: '2011'
   qc6CJjYAAAAJ:0EnyYjriUFMC:
-    citations: 1211
+    citations: 1218
     title: 'The Born Einstein Letters: correspondence between Albert Einstein and Max and Hedwig Born from 1916 to 1955 with commentaries by Max Born. Translated by Irene Born'
     year: '1971'
   qc6CJjYAAAAJ:0KZCP5UExFUC:
@@ -82,7 +82,7 @@ papers:
     title: "Zeitungen gleichen Sparb\xFCchern: dass sie voll geschrieben sind, bedeutet noch nichts."
     year: Unknown Year
   qc6CJjYAAAAJ:0SnApaDgcCoC:
-    citations: 66
+    citations: 69
     title: podolsky B and Rosen N 1935 Phys
     year: Unknown Year
   qc6CJjYAAAAJ:0UEtxawf5sEC:
@@ -126,11 +126,11 @@ papers:
     title: "Albert Einstein] to Michael Pol\xE1nyi: Letter, 8 May 1915"
     year: Unknown Year
   qc6CJjYAAAAJ:17ZO-CJnx_8C:
-    citations: 247
+    citations: 248
     title: "Die Nordstr\xF6msche gravitationstheorie vom standpunkt des absoluten Differentialkalk\xFCls"
     year: '1914'
   qc6CJjYAAAAJ:1AS7WB7zg6gC:
-    citations: 79
+    citations: 80
     title: "L'\xE9ther et la th\xE9orie de la relativit\xE9"
     year: '1921'
   qc6CJjYAAAAJ:1DhOeZtQFr0C:
@@ -158,7 +158,7 @@ papers:
     title: Letter to M Besso
     year: '1942'
   qc6CJjYAAAAJ:1cQOl6Zi554C:
-    citations: 13
+    citations: 14
     title: La lucha contra la guerra
     year: '1986'
   qc6CJjYAAAAJ:1l3MdapXzAoC:
@@ -194,7 +194,7 @@ papers:
     title: "Die Einstein-Sammlung der ETH-Bibliothek in Z\xFCrich: ein Ueberblick f\xFCr Ben\xFCtzer der Handschriften-Abteilung"
     year: '1970'
   qc6CJjYAAAAJ:2C0LhDdYSbcC:
-    citations: 1534
+    citations: 1540
     title: "Le principe de relativit\xE9 et ses cons\xE9quences dans la physique moderne"
     year: '1910'
   qc6CJjYAAAAJ:2KloaMYe4IUC:
@@ -210,7 +210,7 @@ papers:
     title: 'Albert Einstein] to Conrad Habicht: Letter, 15 Apr 1904'
     year: Unknown Year
   qc6CJjYAAAAJ:2ZctHUgIzyAC:
-    citations: 474
+    citations: 476
     title: "La g\xE9om\xE9trie et l'exp\xE9rience"
     year: '1921'
   qc6CJjYAAAAJ:2hfDYGh-f1UC:
@@ -242,7 +242,7 @@ papers:
     title: 'Albert Einstein] to Wilhelm von Siemens: Letter, 4 Jan 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:3fE2CSJIrl8C:
-    citations: 331
+    citations: 332
     title: A generalization of the relativistic theory of gravitation, II
     year: '1946'
   qc6CJjYAAAAJ:3pYxbvHKFu8C:
@@ -258,7 +258,7 @@ papers:
     title: Relativity in Newtonian Mechanics and the Michelson-Morley Experiment
     year: Unknown Year
   qc6CJjYAAAAJ:3vbIHxFL9FgC:
-    citations: 352
+    citations: 353
     title: "Experimenteller Nachweis der Amp\xE8reschen Molekularstr\xF6me"
     year: '1915'
   qc6CJjYAAAAJ:3z7foVzkq2cC:
@@ -270,11 +270,11 @@ papers:
     title: Nachtrag zu meiner Arbeit:Thermodynamische Begruendung des photochemischen Aequivalentgesetzes'(from Annalen der Physik 1912)
     year: '1993'
   qc6CJjYAAAAJ:4Bh_hC5jS3YC:
-    citations: 7161
+    citations: 7178
     title: Graviton Mass and Inertia Mass
     year: '1911'
   qc6CJjYAAAAJ:4DMP91E08xMC:
-    citations: 545
+    citations: 546
     title: The Origins of the General Theory of Relativity
     year: '1933'
   qc6CJjYAAAAJ:4E1Y8I9HL1wC:
@@ -290,7 +290,7 @@ papers:
     title: 'Albert Einstein] to Mileva Einstein-Maric: Letter, 17 Apr 1908'
     year: Unknown Year
   qc6CJjYAAAAJ:4JMBOYKVnBMC:
-    citations: 3000
+    citations: 3005
     title: Quantentheorie des einatomigen idealen Gases
     year: '1924'
   qc6CJjYAAAAJ:4QKQTXcH0q8C:
@@ -346,7 +346,7 @@ papers:
     title: 'Einstein, the Man and His Achievement: A Series of Broadcast Talks'
     year: '1967'
   qc6CJjYAAAAJ:5-tCjTwfAdEC:
-    citations: 463
+    citations: 464
     title: "Die Relativit\xE4tstheorie"
     year: '1915'
   qc6CJjYAAAAJ:5Hlrm_bZEgcC:
@@ -390,7 +390,7 @@ papers:
     title: My theory
     year: '1919'
   qc6CJjYAAAAJ:5pGZGXnFQ_sC:
-    citations: 10686
+    citations: 10745
     title: Sitzungsber. K
     year: '1925'
   qc6CJjYAAAAJ:5qfkUJPXOUwC:
@@ -466,7 +466,7 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 8 Jan 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:7VEv-pLvLSsC:
-    citations: 345
+    citations: 347
     title: "Elementare Betrachtungen \xFCber die thermische Molekularbewegung in festen K\xF6rpern"
     year: '1911'
   qc6CJjYAAAAJ:7XUxBq3GufIC:
@@ -478,7 +478,7 @@ papers:
     title: 'On the Non-existence of Regular Stationary Solutions of Relativistic Field Equations: Annals of Mathematics, Vol. 44, No. 2, April 1943;(received January 4, 1943)'
     year: '1943'
   qc6CJjYAAAAJ:7bRg-L-9LFcC:
-    citations: 14
+    citations: 13
     title: How I see the world
     year: '1991'
   qc6CJjYAAAAJ:7eciy3tyNvQC:
@@ -566,7 +566,7 @@ papers:
     title: "Die Einstein-Dokumente im Archiv der Humboldt-Universit\xE4t zu Berlin"
     year: '1973'
   qc6CJjYAAAAJ:94rQ0kDLHKYC:
-    citations: 4586
+    citations: 4597
     title: Evolution of Physics
     year: '1954'
   qc6CJjYAAAAJ:9CGX2owmTHMC:
@@ -574,11 +574,11 @@ papers:
     title: DIE NATLIRWISSENSCHAFTEN
     year: Unknown Year
   qc6CJjYAAAAJ:9LpHyFPp1DQC:
-    citations: 559
+    citations: 563
     title: "Riemann\u2010Geometrie mit Aufrechterhaltung des Begriffes des Fernparallelismus"
     year: '1928'
   qc6CJjYAAAAJ:9N3KX2BFTccC:
-    citations: 101
+    citations: 102
     title: Elementare Uberlegungen zur Interpretation der Grundlagen der Quanten-Mechanik
     year: '1953'
   qc6CJjYAAAAJ:9PbDelcLwNgC:
@@ -610,7 +610,7 @@ papers:
     title: "Cum v\u0103d eu lumea: o antologie"
     year: '1992'
   qc6CJjYAAAAJ:9tJtKg94vZsC:
-    citations: 210
+    citations: 211
     title: Do gravitational fields play an essential role in the structure of elementary particles?
     year: '1919'
   qc6CJjYAAAAJ:9tletLqOvukC:
@@ -618,7 +618,7 @@ papers:
     title: "Fizika i real\u02B9nost\u02B9: sbornik state\u012D"
     year: '1965'
   qc6CJjYAAAAJ:9u2w3wkYHSMC:
-    citations: 97
+    citations: 98
     title: "Maxwell\u2019s influence on the development of the conception of physical reality"
     year: '1931'
   qc6CJjYAAAAJ:9xDRhSErrBIC:
@@ -642,7 +642,7 @@ papers:
     title: "Wir sind gewarnt. Mit einem Vorw. von Albert Einstein.[Aus dem franz\xF6sischen \xFCbertr. von W. Theimer]."
     year: '1955'
   qc6CJjYAAAAJ:AFXcoJnoRH0C:
-    citations: 84
+    citations: 85
     title: Einheitliche Feldtheorie und Hamiltonsches Prinzip
     year: '2006'
   qc6CJjYAAAAJ:APw3zysQxTcC:
@@ -654,7 +654,7 @@ papers:
     title: La relativit# a speciale
     year: '1920'
   qc6CJjYAAAAJ:AVQCy-ZCKIsC:
-    citations: 116
+    citations: 115
     title: "Planck\u2019s theory of radiation and the theory of specific heat"
     year: '1907'
   qc6CJjYAAAAJ:AYaE08C4-t8C:
@@ -706,7 +706,7 @@ papers:
     title: "Zu Kaluzas Theorie des Zusammenhanges von Gravitation und Elektrizit\xE4t. Erste Mitteilung"
     year: '2006'
   qc6CJjYAAAAJ:BUYA1_V_uYcC:
-    citations: 110
+    citations: 111
     title: "La th\xE9orie de la relativit\xE9 restreinte et g\xE9n\xE9rale"
     year: '1990'
   qc6CJjYAAAAJ:BW2nPTmhBn4C:
@@ -718,7 +718,7 @@ papers:
     title: VI. GRAVITATIONAL WAVES
     year: '1979'
   qc6CJjYAAAAJ:BjLbhSWBl98C:
-    citations: 223
+    citations: 225
     title: "Experimental proof of the existence of Amp\xE8re's molecular currents"
     year: '1915'
   qc6CJjYAAAAJ:BnRbUGEozz8C:
@@ -766,15 +766,15 @@ papers:
     title: 'Albert Einstein] to Paul Seippel: Letter, 19 Aug 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:CLQ-NLsb8zAC:
-    citations: 3173
+    citations: 3183
     title: Ideas and Opinions
     year: '1954'
   qc6CJjYAAAAJ:COU-sansr_wC:
-    citations: 95
+    citations: 96
     title: "Elie Cartan-Albert Einstein: lettres sur le parall\xE9lisme absolu 1929-1932"
     year: '1979'
   qc6CJjYAAAAJ:CQX_Vi8q7s0C:
-    citations: 1971
+    citations: 1975
     title: Introduction Einstein's Relativity
     year: '1992'
   qc6CJjYAAAAJ:CRQ797xmLJIC:
@@ -790,7 +790,7 @@ papers:
     title: "Untersuchungen \xFCber die Theorie der Brownschen Bewegung/Abhandlungen \xFCber die Brownsche Bewegung und verwandte Erscheinungen"
     year: '1999'
   qc6CJjYAAAAJ:CY3uIpTmi-gC:
-    citations: 150
+    citations: 152
     title: Einstein on Cosmic Religion and Other Opinions and Aphorisms
     year: '2009'
   qc6CJjYAAAAJ:CmbFvBriOyMC:
@@ -810,11 +810,11 @@ papers:
     title: Improvements relating to refrigerating apparatus
     year: '1927'
   qc6CJjYAAAAJ:CrVLTnlDqZQC:
-    citations: 16
+    citations: 18
     title: On the moral obligation of the scientist
     year: '1945'
   qc6CJjYAAAAJ:Cv-mv52rCCkC:
-    citations: 5327
+    citations: 5336
     title: On the motion of particles suspended in a liquid at rest, assumed by the molecular-kinetic theory of heat
     year: '1905'
   qc6CJjYAAAAJ:Cx2ibDnldiAC:
@@ -858,7 +858,7 @@ papers:
     title: Jarbuch der Radioaktivitat und Elektronik, 4, 411 (1907), reprinted in The Collected Papers of A. Einstein, vol. 2, 252
     year: '1989'
   qc6CJjYAAAAJ:DQNrXyjhriIC:
-    citations: 3147
+    citations: 3185
     title: Die feldgleichungen der gravitation
     year: '1915'
   qc6CJjYAAAAJ:D_sINldO8mEC:
@@ -866,7 +866,7 @@ papers:
     title: Essays in humanism
     year: '2011'
   qc6CJjYAAAAJ:DejRBzv9GVYC:
-    citations: 72
+    citations: 70
     title: 'Ueber den Frieden: Weltordnung oder Weltuntergang?'
     year: '1975'
   qc6CJjYAAAAJ:Dh4RK7yvr34C:
@@ -890,7 +890,7 @@ papers:
     title: 'The Origins of the General Theory of Relativity: Being the First Lecture on the George A. Gibson Foundation in the University of Glasgow, Delivered on June 20th, 1933'
     year: '1933'
   qc6CJjYAAAAJ:DtORCzn_ASQC:
-    citations: 104
+    citations: 103
     title: Quantum mechanics and reality
     year: '1948'
   qc6CJjYAAAAJ:DxlTmyU89zoC:
@@ -898,7 +898,7 @@ papers:
     title: Kreative Methoden 239 Kindern in Deutsehland lebensweltliche Erfahrungen von politischen Er
     year: Unknown Year
   qc6CJjYAAAAJ:E2bRg1zSkIsC:
-    citations: 287
+    citations: 288
     title: A teoria da relatividade especial e geral
     year: '2003'
   qc6CJjYAAAAJ:E2dP09oujfMC:
@@ -946,7 +946,7 @@ papers:
     title: "Sur le probl\xE8me de la formation de la personnalit\xE9 cr\xE9atrice d'Einstein."
     year: Unknown Year
   qc6CJjYAAAAJ:Ei5r6KrKXVQC:
-    citations: 1517
+    citations: 1523
     title: "Theorie der Opaleszenz von homogenen Fl\xFCssigkeiten und Fl\xFCssigkeitsgemischen in der N\xE4he des kritischen Zustandes"
     year: '2006'
   qc6CJjYAAAAJ:EpJ50YjRFhcC:
@@ -986,7 +986,7 @@ papers:
     title: 'Einstein: Science and Religion'
     year: Unknown Year
   qc6CJjYAAAAJ:FKYJxdYMdFIC:
-    citations: 999
+    citations: 1003
     title: "The Collected Papers of Albert Einstein, Volume 15 (Translation Supplement): The Berlin Years: Writings & Correspondence, June 1925\u2013May 1927"
     year: '2018'
   qc6CJjYAAAAJ:FKzTm0Bp8ZYC:
@@ -1062,7 +1062,7 @@ papers:
     title: Systematische Untersuchung fiber kompatible Feldgleichungen, welche von einem Riemannschen Raum mit Fernparallelismus gesetzt werden k6nnen
     year: '1931'
   qc6CJjYAAAAJ:G36d5HCDkJYC:
-    citations: 215
+    citations: 216
     title: Remarks on Bertrand Russell's theory of knowledge
     year: '1946'
   qc6CJjYAAAAJ:GCDlZl827dEC:
@@ -1118,11 +1118,11 @@ papers:
     title: 'Zitate Aus Mein Weltbild: Sieben Radierungen Von Terry Haass'
     year: '1975'
   qc6CJjYAAAAJ:Gpwnp1kGG20C:
-    citations: 259
+    citations: 260
     title: Ernst Mach
     year: '1916'
   qc6CJjYAAAAJ:Grx829lh2T4C:
-    citations: 3110
+    citations: 3118
     title: Quantum theory of monatomic ideal gases
     year: '1924'
   qc6CJjYAAAAJ:GsgvGxwuA5UC:
@@ -1142,7 +1142,7 @@ papers:
     title: "Theorien verborgener Parameter, EPR-Korrelationen, Bell\u2019sche Ungleichung, GHZ-Zust ande"
     year: '1999'
   qc6CJjYAAAAJ:GzlcqhCAosUC:
-    citations: 493
+    citations: 494
     title: "QUANTEN\u2010MECHANIK UND WIRKLICHKEIT"
     year: '1948'
   qc6CJjYAAAAJ:H-nlc5mcmJQC:
@@ -1178,11 +1178,11 @@ papers:
     title: Riemann-Metrik mit Aufrechterhaltung des Begriffes der Fern-parallelismus, Preuss
     year: '1928'
   qc6CJjYAAAAJ:HklM7qHXWrUC:
-    citations: 463
+    citations: 464
     title: "Die Relativit\xE4tstheorie"
     year: '1925'
   qc6CJjYAAAAJ:Hl4CZ0n6gBQC:
-    citations: 21750
+    citations: 21824
     title: Uber einen die Erzeugung und Verwandlung des Lichtes betreffenden heurischen Gesichtpunkt
     year: '1905'
   qc6CJjYAAAAJ:HtEfBTGE9r8C:
@@ -1210,11 +1210,11 @@ papers:
     title: "\xC4ther und Relativit\xE4tstheorie: Rede gehalten am 5. Mai 1920 an der Reichs-Universit\xE4t zu Leiden"
     year: '1920'
   qc6CJjYAAAAJ:IEpB_1CIIT4C:
-    citations: 3953
+    citations: 3963
     title: 'THE EVOLUTION OF PHYSICS: THE GROWTH OF IDEAS FROM THE EARLY CON CEPTS TO RELATIVITY AND QUANTA.'
     year: '1938'
   qc6CJjYAAAAJ:IHkkN1K1AlAC:
-    citations: 67
+    citations: 68
     title: "Beitr\xE4ge zur Quantentheorie"
     year: '1914'
   qc6CJjYAAAAJ:IMJZBBnUFLgC:
@@ -1226,7 +1226,7 @@ papers:
     title: Sehallausbreitung in teilweise disseziierten Gasen.
     year: '1920'
   qc6CJjYAAAAJ:IWHjjKOFINEC:
-    citations: 805
+    citations: 811
     title: Cosmological considerations on the general theory of relativity
     year: '1986'
   qc6CJjYAAAAJ:IZKZNMMMWs0C:
@@ -1246,7 +1246,7 @@ papers:
     title: 'The collected papers of Albert Einstein. Vol 4, The Swiss years: writings, 1912-1914 [English translation]'
     year: Unknown Year
   qc6CJjYAAAAJ:IjCSPb-OGe4C:
-    citations: 1409
+    citations: 1413
     title: The gravitational equations and the problem of motion
     year: '1938'
   qc6CJjYAAAAJ:IkxDsZK-5NQC:
@@ -1258,7 +1258,7 @@ papers:
     title: 'Zu Max Plancks sechzegstem Geburtstag: Ansprachen, gehalten am 26. April 1918 in der Deutschen Physikalischen Gesellschaft'
     year: '1918'
   qc6CJjYAAAAJ:IqrShC7OVU0C:
-    citations: 6518
+    citations: 6529
     title: Investigations on the theory of the Brownian movement, edited with notes by R
     year: '1926'
   qc6CJjYAAAAJ:IvSMUa3B7yYC:
@@ -1266,7 +1266,7 @@ papers:
     title: "Berichtigung zur Abhandlung:\u201E\xDCber die elektromagnetischen Grundgleichungen f\xFCr bewegte K\xF6rper\u201D \uFE01"
     year: '1908'
   qc6CJjYAAAAJ:J-pR_7NvFogC:
-    citations: 847
+    citations: 851
     title: 'The Swiss Years: Writings, 1914-1917'
     year: '1996'
   qc6CJjYAAAAJ:J4wmHkHhN-kC:
@@ -1278,7 +1278,7 @@ papers:
     title: Tables of Einstein Functions
     year: '1962'
   qc6CJjYAAAAJ:JQPmwQThujIC:
-    citations: 474
+    citations: 476
     title: "La g\xE9om\xE9trie et l'exp\xE9rience, par Albert Einstein; traduit par Maurice Solovine"
     year: '1921'
   qc6CJjYAAAAJ:JXi_AgyUMBAC:
@@ -1286,11 +1286,11 @@ papers:
     title: Relativistic theory of the non-symmetric field
     year: '1955'
   qc6CJjYAAAAJ:JZsVLox4iN8C:
-    citations: 2472
+    citations: 2482
     title: 'Autobiographisches in: Albert Einstein: Philosopher-Scientist'
     year: '1949'
   qc6CJjYAAAAJ:J_g5lzvAfSwC:
-    citations: 140
+    citations: 136
     title: Warum Krieg?
     year: '1972'
   qc6CJjYAAAAJ:JjPkQosUWiAC:
@@ -1310,11 +1310,11 @@ papers:
     title: "Briefe zur Wellenmechanik: Schr\xF6dinger, Planck, Einstein, Lorentz"
     year: '1963'
   qc6CJjYAAAAJ:K3LRdlH-MEoC:
-    citations: 82
+    citations: 83
     title: Fundamental ideas and problems of the theory of relativity
     year: '2009'
   qc6CJjYAAAAJ:K4-iKlO5MD4C:
-    citations: 765
+    citations: 773
     title: A Heuristic Viewpoint Concerning the Production and Transformation of Light
     year: '1929'
   qc6CJjYAAAAJ:K6kyChav4UkC:
@@ -1354,7 +1354,7 @@ papers:
     title: Physiology and Pathophysiology of the Heart
     year: '1990'
   qc6CJjYAAAAJ:KVXOKlNwS8oC:
-    citations: 62
+    citations: 63
     title: 'Briefwechsel [zwischen] Albert Einstein und Arnold Sommerfeld: sechzig Briefe aus dem goldenen Zeitalter der modernen Physik'
     year: '1968'
   qc6CJjYAAAAJ:Kaaf24wrr50C:
@@ -1390,7 +1390,7 @@ papers:
     title: 'Albert Einstein] to Mileva Einstein-Maric: Letter, after 17 Mar 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:L7JqRCIhofwC:
-    citations: 6884
+    citations: 6898
     title: Sitzungsberichte der Preussischen Akademie der Wissenschaften zu Berlin
     year: '1915'
   qc6CJjYAAAAJ:L7vk9XBBNxgC:
@@ -1454,11 +1454,11 @@ papers:
     title: 'Albert Einstein] to Hedwig Born: Letter, 8 Feb 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:LkGwnXOMwfcC:
-    citations: 3245
+    citations: 3272
     title: The foundation of the general theory of relativity
     year: '1916'
   qc6CJjYAAAAJ:LkrQC8aPkXYC:
-    citations: 5474
+    citations: 5503
     title: 'Relativity: The Special and the General Theory: a Popular Exposition by Albert Einstein; Transl. by Robert W. Lawson'
     year: '1961'
   qc6CJjYAAAAJ:Lmuc1furtc4C:
@@ -1514,7 +1514,7 @@ papers:
     title: El significado de la relatividad
     year: '1971'
   qc6CJjYAAAAJ:MDX3w3dAD3YC:
-    citations: 919
+    citations: 922
     title: Zum quantensatz von Sommerfeld und Epstein
     year: '1917'
   qc6CJjYAAAAJ:MGPUR4WVBMEC:
@@ -1526,7 +1526,7 @@ papers:
     title: New possibility for a unified field theory of gravitation and electricity
     year: '1928'
   qc6CJjYAAAAJ:MNNNGtAgD4EC:
-    citations: 346
+    citations: 344
     title: "Bemerkung zu dem Gesetz von E\xF6tv\xF6s"
     year: '1911'
   qc6CJjYAAAAJ:MTuJV9umhWMC:
@@ -1538,7 +1538,7 @@ papers:
     title: "La corr\xE9lation de l'empirique et du rationnel dans l'oeuvre scientifique d'Einstein."
     year: Unknown Year
   qc6CJjYAAAAJ:MXK_kJrjxJIC:
-    citations: 649
+    citations: 652
     title: On a stationary system with spherical symmetry consisting of many gravitating masses
     year: '1939'
   qc6CJjYAAAAJ:MqTxh1vmwXEC:
@@ -1570,7 +1570,7 @@ papers:
     title: The advent of the quantum theory
     year: '1951'
   qc6CJjYAAAAJ:NM66qo_NnlUC:
-    citations: 1032
+    citations: 1036
     title: 'The Collected Papers of Albert Einstein: English Translation'
     year: '1989'
   qc6CJjYAAAAJ:NMxIlDl6LWMC:
@@ -1602,7 +1602,7 @@ papers:
     title: Albert Einstein] to Michele Besso:[A first] letter, 21 Jul 1916
     year: Unknown Year
   qc6CJjYAAAAJ:NZNkWSpQBv0C:
-    citations: 88
+    citations: 89
     title: Zum Ehrenfestschen Paradoxon
     year: '1910'
   qc6CJjYAAAAJ:NnTm98qLMbgC:
@@ -1622,7 +1622,7 @@ papers:
     title: Sidelights on Relativity,... I. Ether and Relativity. II. Geometry and Experience
     year: '1922'
   qc6CJjYAAAAJ:Nufq_to8ts0C:
-    citations: 206
+    citations: 208
     title: "Das Prinzip von der Erhaltung der Schwerpunktsbewegung und die Tr\xE4gheit der Energie"
     year: '1906'
   qc6CJjYAAAAJ:Nw5Pwe77XXAC:
@@ -1630,7 +1630,7 @@ papers:
     title: 'Albert Einstein] to Wilhelm Wien: Letter, 17 Oct 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:Nw_I7GeUguwC:
-    citations: 167
+    citations: 169
     title: "Zur allgemeinen molekularen Theorie der W\xE4rme"
     year: '1904'
   qc6CJjYAAAAJ:NzUpm4bhSXQC:
@@ -1662,7 +1662,7 @@ papers:
     title: 'Friedrich Wilhelm Foerster und Albert Einstein: Briefwechsel von 1935 bis 1954'
     year: '2001'
   qc6CJjYAAAAJ:OPs5gEIPXMUC:
-    citations: 8383
+    citations: 8432
     title: On gravitational waves Sitzungsber. preuss
     year: '1918'
   qc6CJjYAAAAJ:OTTXONDVkokC:
@@ -1694,7 +1694,7 @@ papers:
     title: On German Literature for Viola Da Gamba in the 16th and 17th Centuries
     year: '1977'
   qc6CJjYAAAAJ:P1qO8dLd1z8C:
-    citations: 273
+    citations: 274
     title: The Photoelectric Effect
     year: '1905'
   qc6CJjYAAAAJ:P9oYG7HA76QC:
@@ -1706,7 +1706,7 @@ papers:
     title: Deutsche Physikalische Gesellschaft
     year: '1915'
   qc6CJjYAAAAJ:PPAp3RzCAaIC:
-    citations: 62
+    citations: 63
     title: 'Briefwechsel: Albert Einstein, Arnold Sommerfeld: Sechzig Briefe Aus Dem Goldenen Zeitalter Der Modernen Physik'
     year: '1968'
   qc6CJjYAAAAJ:PQm_lTwdG-sC:
@@ -1734,7 +1734,7 @@ papers:
     title: 'Wissenschaftlicher Briefwechsel Mit Bohr, Einstein, Heisenberg, Ua: Scientific Correspondence with Bohr, Einstein, Heisenberg, Ao Volume 1: 1919-1929. 1919-1929'
     year: '1979'
   qc6CJjYAAAAJ:Q7hiZQKJ-pAC:
-    citations: 228
+    citations: 227
     title: 'Cosmic religion: with other opinions and aphorisms'
     year: '1931'
   qc6CJjYAAAAJ:Q9ss7R9eeXsC:
@@ -1758,7 +1758,7 @@ papers:
     title: "Cien a\xF1os de relatividad: Los art\xEDculos de Albert Einstein de 1905 y 1906"
     year: '2004'
   qc6CJjYAAAAJ:QIV2ME_5wuYC:
-    citations: 777
+    citations: 782
     title: Does the inertia of a body depend upon its energy-content?
     year: '1905'
   qc6CJjYAAAAJ:QKtdBID3u5MC:
@@ -1778,7 +1778,7 @@ papers:
     title: My Attitude to Quantum Theory
     year: '1950'
   qc6CJjYAAAAJ:QYdC8u9Cj1oC:
-    citations: 13
+    citations: 14
     title: Special and General relativity
     year: '1920'
   qc6CJjYAAAAJ:Q_E8KsG3g9MC:
@@ -1834,11 +1834,11 @@ papers:
     title: "Lettres \xE0 Maurice Solovine"
     year: '1956'
   qc6CJjYAAAAJ:R6aXIXmdpM0C:
-    citations: 3
+    citations: 4
     title: Pourquoi le socialisme?
     year: '1993'
   qc6CJjYAAAAJ:RF4BjkDOTHkC:
-    citations: 979
+    citations: 978
     title: "Letters on Wave Mechanics: Correspondence with HA Lorentz, Max Planck, and Erwin Schr\xF6dinger"
     year: '2011'
   qc6CJjYAAAAJ:RJNGbXJAtMsC:
@@ -1854,7 +1854,7 @@ papers:
     title: Bemerkungen iiber den Wandel der Problemstcllungen in der theoretischen Physik
     year: Unknown Year
   qc6CJjYAAAAJ:RfUwGJFMQ-0C:
-    citations: 4552
+    citations: 4564
     title: Zur quantentheorie der strahlung
     year: '1917'
   qc6CJjYAAAAJ:RgMnzfD6kpIC:
@@ -1874,11 +1874,11 @@ papers:
     title: "Briefe zur Wellenmechanik: Mit 4 portr\xE4ts"
     year: '1963'
   qc6CJjYAAAAJ:S2WlVNSe3u4C:
-    citations: 129
+    citations: 130
     title: "Kinetische Theorie des W\xE4rmegleichgewichtes und des zweiten Hauptsatzes der Thermodynamik"
     year: '1902'
   qc6CJjYAAAAJ:S9V7H-Nz35UC:
-    citations: 7777
+    citations: 7818
     title: On a Heuristic Point of View Toward the Emission and Transformation of Light
     year: '1905'
   qc6CJjYAAAAJ:SFOYbPikdlgC:
@@ -1902,7 +1902,7 @@ papers:
     title: Albert einstein to max born
     year: '2005'
   qc6CJjYAAAAJ:Se3iqnhoufwC:
-    citations: 989
+    citations: 988
     title: The world as I see it
     year: '2007'
   qc6CJjYAAAAJ:SenaEjHFqFYC:
@@ -1926,7 +1926,7 @@ papers:
     title: 'Albert Einstein] to Wander and Geertruida de Haas: Letter, 3 Oct 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:SrKkpNFED5gC:
-    citations: 596
+    citations: 598
     title: "Zum gegenw\xE4rtigen Stand des Strahlungsproblems"
     year: '1909'
   qc6CJjYAAAAJ:SrsqWtBqNIQC:
@@ -1938,7 +1938,7 @@ papers:
     title: 'Albert Einstein] to Wladyslaw Natanson: Letter, 24 Aug 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:SzsLJvG5eXAC:
-    citations: 2042
+    citations: 2050
     title: Autobiographical Notes, ed
     year: '1979'
   qc6CJjYAAAAJ:T64LSalLz9oC:
@@ -1958,11 +1958,11 @@ papers:
     title: Letters on wave mechanics
     year: '1967'
   qc6CJjYAAAAJ:TGemctCAZTQC:
-    citations: 34
+    citations: 35
     title: The new field theory
     year: '1929'
   qc6CJjYAAAAJ:TIZ-Mc8IlK0C:
-    citations: 1114
+    citations: 1118
     title: On the method of theoretical physics
     year: '1934'
   qc6CJjYAAAAJ:TKTY8N1AUUAC:
@@ -1990,7 +1990,7 @@ papers:
     title: "Hamilton\u2019s principle and the general theory of relativity"
     year: '1916'
   qc6CJjYAAAAJ:TiIbgCYny7sC:
-    citations: 9478
+    citations: 9533
     title: "Zur Elektrodynamik bewegter K\xF6rper"
     year: Unknown Year
   qc6CJjYAAAAJ:TmnWbB_axlEC:
@@ -2006,7 +2006,7 @@ papers:
     title: Bemerkung zu E. Gehrckes Notiz
     year: '1918'
   qc6CJjYAAAAJ:UC7Jl7-kV0oC:
-    citations: 162
+    citations: 163
     title: Scientific papers presented to Max Born
     year: '1953'
   qc6CJjYAAAAJ:UEa65astgjsC:
@@ -2046,7 +2046,7 @@ papers:
     title: The Effect of Autonomous Algorithms on Networking
     year: Unknown Year
   qc6CJjYAAAAJ:UeHWp8X0CEIC:
-    citations: 59
+    citations: 60
     title: "Sobre la electrodin\xE1mica de los cuerpos en movimiento"
     year: '2005'
   qc6CJjYAAAAJ:UebtZRa9Y70C:
@@ -2058,7 +2058,7 @@ papers:
     title: On a Jewish Palestine. First Version, before 27 Jun 1921
     year: Unknown Year
   qc6CJjYAAAAJ:Ul_CLA4dPeMC:
-    citations: 212
+    citations: 213
     title: 'Religion and Science: Irreconcilable?'
     year: '1948'
   qc6CJjYAAAAJ:UnhBtiQKoKQC:
@@ -2066,7 +2066,7 @@ papers:
     title: 'The Swiss Years: Writing 1900-1909:...'
     year: '1989'
   qc6CJjYAAAAJ:UoSa6IK8DwsC:
-    citations: 14
+    citations: 15
     title: from The Einstein-Freud Correspondence (1931-1932)
     year: '1960'
   qc6CJjYAAAAJ:UuaQgmrAG1sC:
@@ -2158,11 +2158,11 @@ papers:
     title: THE FREEDOM OF LEARNING.
     year: '1936'
   qc6CJjYAAAAJ:W6h41lW4BooC:
-    citations: 31
+    citations: 32
     title: "L'\xE9tat actuel du probl\xE8me des chaleurs sp\xE9cifiques"
     year: '1912'
   qc6CJjYAAAAJ:W7OEmFMy1HYC:
-    citations: 1643
+    citations: 1646
     title: Lens-like action of a star by the deviation of light in the gravitational field
     year: '1936'
   qc6CJjYAAAAJ:WC4w5-ZrDNIC:
@@ -2174,7 +2174,7 @@ papers:
     title: La discussion Einstein-Bohr.
     year: Unknown Year
   qc6CJjYAAAAJ:WF5omc3nYNoC:
-    citations: 1064
+    citations: 1065
     title: On gravitational waves
     year: '1937'
   qc6CJjYAAAAJ:WIVIxizkzXoC:
@@ -2182,7 +2182,7 @@ papers:
     title: 'Albert Einstein] to Paul Ehrenfest: Letter, 26 Dec 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:WIXB4To3Tx4C:
-    citations: 105
+    citations: 106
     title: "Relativit\xE4t und gravitation. Erwiderung auf eine bemerkung von M. Abraham"
     year: '1912'
   qc6CJjYAAAAJ:WM2K3OHRCGMC:
@@ -2274,7 +2274,7 @@ papers:
     title: 'Albert Einstein] to Paul Gruner: Letter, 11 Feb 1908'
     year: Unknown Year
   qc6CJjYAAAAJ:XZvG1uL-wj0C:
-    citations: 1162
+    citations: 1166
     title: 'On the method of theoretical physics: The Herbert Spencer lecture, delivered at Oxford 10 June 1933'
     year: '1933'
   qc6CJjYAAAAJ:Xc-mKOjpdrwC:
@@ -2286,7 +2286,7 @@ papers:
     title: 'The Collected Papers of Albert Einstein, Volume 9: The Berlin Years: Correspondence, January 1919-April 1920'
     year: '2004'
   qc6CJjYAAAAJ:XdwVV_xN3QMC:
-    citations: 1539
+    citations: 1549
     title: Draft of a Generalized Theory of Relativity and a Theory of Gravitation
     year: '1913'
   qc6CJjYAAAAJ:XeErXHja3Z8C:
@@ -2322,7 +2322,7 @@ papers:
     title: "Research@ FrankfurtSchool in Zeiten der Finanzmarktkrise \u201EA Collection of Working Papers \u201C"
     year: Unknown Year
   qc6CJjYAAAAJ:Y0agIcFmOsQC:
-    citations: 1208
+    citations: 1212
     title: A correction on my work-A new determination of molecular dimensions
     year: '1969'
   qc6CJjYAAAAJ:Y1W0x10ZrwMC:
@@ -2390,7 +2390,7 @@ papers:
     title: 'Albert Einstein] to Michele and Anna Besso-Winteler: Letter, 1 Aug 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:YsMSGLbcyi4C:
-    citations: 2407
+    citations: 2427
     title: The particle problem in the general theory of relativity
     year: '1935'
   qc6CJjYAAAAJ:YvgfBAebZEkC:
@@ -2426,11 +2426,11 @@ papers:
     title: "Bemerkung zu E. Gehrckes Notiz\" \xDCber den \xC4ther\", 29 Nov 1918"
     year: Unknown Year
   qc6CJjYAAAAJ:ZYLUaBFA95QC:
-    citations: 12
+    citations: 13
     title: 'Briefwechsel: Sechzig Briefe aus dem goldenen Zeitalter der modernen Physik'
     year: '1968'
   qc6CJjYAAAAJ:ZbQVaL1IMbQC:
-    citations: 4102
+    citations: 4110
     title: Quanzeml~ orie der stralllung
     year: '1916'
   qc6CJjYAAAAJ:ZbiiB1Sm8G8C:
@@ -2438,11 +2438,11 @@ papers:
     title: 'Albert Einstein] to Michele Besso: Letter, 6 Apr 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:ZeXyd9-uunAC:
-    citations: 352
+    citations: 354
     title: "Physik und realit\xE4t"
     year: '1936'
   qc6CJjYAAAAJ:ZfRJV9d4-WMC:
-    citations: 99
+    citations: 100
     title: Pourquoi la guerre?
     year: '1933'
   qc6CJjYAAAAJ:ZgPQhQxLujAC:
@@ -2458,7 +2458,7 @@ papers:
     title: 'Relativiteit: speciale en algemene theorie'
     year: '1986'
   qc6CJjYAAAAJ:Zph67rFs4hoC:
-    citations: 398
+    citations: 400
     title: "Grundz\xFCge der Relativit\xE4tstheorie"
     year: '2002'
   qc6CJjYAAAAJ:ZppSRAJs3i8C:
@@ -2506,7 +2506,7 @@ papers:
     title: Theoretical remark on the superconductivity of metals
     year: '2005'
   qc6CJjYAAAAJ:_bh1rdP-zDcC:
-    citations: 39
+    citations: 40
     title: "Die Diracgleichungen f\xFCr Semivektoren"
     year: '1933'
   qc6CJjYAAAAJ:_inCrQx-FbQC:
@@ -2518,7 +2518,7 @@ papers:
     title: A generalization of the relativistic theory of gravitation
     year: '1945'
   qc6CJjYAAAAJ:_mQi-xiA4oYC:
-    citations: 463
+    citations: 464
     title: "Die Relativit\xE4ts-Theorie"
     year: '1911'
   qc6CJjYAAAAJ:a2necdfpwlEC:
@@ -2526,7 +2526,7 @@ papers:
     title: "Eine Beziehung zwischen dem elastischen Verhalten und der spezifischen W\xE4rme bei festen K\xF6rpern mit einatomigem Molek\xFCl"
     year: '1911'
   qc6CJjYAAAAJ:a9-T7VOCCH8C:
-    citations: 3807
+    citations: 3814
     title: The Science and the Life of Albert Einstein
     year: '1982'
   qc6CJjYAAAAJ:aDdGf5um_jkC:
@@ -2534,11 +2534,11 @@ papers:
     title: 'Albert Einstein] to Gustav Mie: Letter, 2 Jun 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:aEPHIGigqugC:
-    citations: 4358
+    citations: 4376
     title: "Physics and Reality, in \u201CIdeas and Opinions\u201D"
     year: '1954'
   qc6CJjYAAAAJ:aEyKTaVlRPYC:
-    citations: 10
+    citations: 11
     title: El mundo tal como yo lo veo
     year: '1989'
   qc6CJjYAAAAJ:aKos2Y7kUz0C:
@@ -2566,7 +2566,7 @@ papers:
     title: The fundamentals of theoretical physics
     year: '1950'
   qc6CJjYAAAAJ:ace9KxS0p5UC:
-    citations: 287
+    citations: 285
     title: Zur theorie der lichterzeugung und lichtabsorption
     year: '1906'
   qc6CJjYAAAAJ:adHtZc2wMuEC:
@@ -2582,7 +2582,7 @@ papers:
     title: "Albert Einstein] to Michael Pol\xE1nyi: Letter, 6 Jul 1915"
     year: Unknown Year
   qc6CJjYAAAAJ:afceBpUbn5YC:
-    citations: 58
+    citations: 59
     title: Atomic education urged by Einstein
     year: '1946'
   qc6CJjYAAAAJ:afcu1OVO0wMC:
@@ -2602,7 +2602,7 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 26 Nov 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:bCjgOgSFrM0C:
-    citations: 1285
+    citations: 1289
     title: "Die plancksche theorie der strahlung und die theorie der spezifischen w\xE4rme"
     year: '1906'
   qc6CJjYAAAAJ:bEWYMUwI8FkC:
@@ -2626,7 +2626,7 @@ papers:
     title: 'Albert Einstein] to Paul Hertz: Letter, 22 Aug 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:bUu3lypoyhcC:
-    citations: 828
+    citations: 833
     title: On the quantum theory of radiation
     year: '1972'
   qc6CJjYAAAAJ:bcT4vkklUMwC:
@@ -2642,7 +2642,7 @@ papers:
     title: Kinetic theory of thermal equilibrium and of the second law of thermodynamics
     year: '1902'
   qc6CJjYAAAAJ:bgW0xdllhO4C:
-    citations: 17
+    citations: 18
     title: Personal God Concept Causes Science-Religion Conflict
     year: '1940'
   qc6CJjYAAAAJ:bjlTY1bLvvcC:
@@ -2662,7 +2662,7 @@ papers:
     title: 'The collected papers of Albert Einstein. vol. 9, The Berlin years: correspondence, January 1919-April 1920:[English translation]'
     year: Unknown Year
   qc6CJjYAAAAJ:brChLMnLtjYC:
-    citations: 185
+    citations: 186
     title: Relativity Principle and its Consequences in Modern Physics. Collection of Scientific Works, V. 1
     year: '1965'
   qc6CJjYAAAAJ:bsl25C5uMOsC:
@@ -2686,7 +2686,7 @@ papers:
     title: The Fight Against War
     year: '1933'
   qc6CJjYAAAAJ:c4A-nLdbYHEC:
-    citations: 1561
+    citations: 1562
     title: 'Concepts of space: The history of theories of space in physics'
     year: '1969'
   qc6CJjYAAAAJ:c5LcigzBm8MC:
@@ -2694,7 +2694,7 @@ papers:
     title: 'Albert Einstein] to Heinrich Zangger: Letter, 24 Jun 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:cB__R-XWw9UC:
-    citations: 162
+    citations: 163
     title: "Aus meinen sp\xE4ten Jahren"
     year: '1952'
   qc6CJjYAAAAJ:cG0OFEevkNgC:
@@ -2702,7 +2702,7 @@ papers:
     title: 'In Memory of Emmy Noether...: Abstract of Address Delivered by Professor Hermann Weyl... and Copy of Letter of Professor Albert Einstein'
     year: '1935'
   qc6CJjYAAAAJ:cNe27ouKFcQC:
-    citations: 7862
+    citations: 7913
     title: "Die grundlage der allgemeinen relativit\xE4tstheorie"
     year: '2006'
   qc6CJjYAAAAJ:cOfwuRB03ygC:
@@ -2710,11 +2710,11 @@ papers:
     title: "Die spezielle relativit\xE4tstheorie Einsteins und die logik"
     year: '1924'
   qc6CJjYAAAAJ:cRMvf6lLvU8C:
-    citations: 293
+    citations: 292
     title: "Einige Argumente f\xFCr die Annahme einer molekularen Agitation beim absoluten Nullpunkt"
     year: '1913'
   qc6CJjYAAAAJ:cSdaV2aYdYsC:
-    citations: 379
+    citations: 380
     title: Spielen Gravitationsfelder im Aufbau der materiellen Elementarteilchen eine wesentliche Rolle?
     year: '1919'
   qc6CJjYAAAAJ:cTdzRpWJKHEC:
@@ -2746,7 +2746,7 @@ papers:
     title: "cr\xE9ateur et rebelle"
     year: '1972'
   qc6CJjYAAAAJ:cww_0JKUTDwC:
-    citations: 170
+    citations: 171
     title: Eine Theorie der Grundlagen der Thermodynamik
     year: '1903'
   qc6CJjYAAAAJ:cxS_fjKIGZMC:
@@ -2758,7 +2758,7 @@ papers:
     title: "Signification de la relativit\xE9: appendice \xE0 la cinqui\xE8me \xE9dition de\" The meaning of relativity\"(d\xE9cembre 1954). Compl\xE9ments"
     year: '1960'
   qc6CJjYAAAAJ:d4tt_xEv1X8C:
-    citations: 221
+    citations: 223
     title: Lichtgeschwindigkeit und statik des Gravitationsfeldes
     year: '1912'
   qc6CJjYAAAAJ:d6JCS5z0ckYC:
@@ -2766,7 +2766,7 @@ papers:
     title: The establishment of an international bureau of meteorology
     year: '1927'
   qc6CJjYAAAAJ:dBIO0h50nwkC:
-    citations: 49
+    citations: 50
     title: Physics & reality
     year: '2003'
   qc6CJjYAAAAJ:dDz6LBb16w8C:
@@ -2802,7 +2802,7 @@ papers:
     title: 'Albert Einstein] to Max Born: Letter, after 3 Jul 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:dhFuZR0502QC:
-    citations: 202
+    citations: 203
     title: 'Corrections and additional remarks to our paper: The influence of the expansion of space on the gravitation fields surrounding the individual stars'
     year: '1946'
   qc6CJjYAAAAJ:dhZ1Wuf5EGsC:
@@ -2826,7 +2826,7 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 4 Nov 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:e84hm74t-eoC:
-    citations: 5815
+    citations: 5828
     title: "Eine neue bestimmung der molek\xFCldimensionen"
     year: '1906'
   qc6CJjYAAAAJ:eAUscmXIlQ8C:
@@ -2842,7 +2842,7 @@ papers:
     title: Besprechungen
     year: '1918'
   qc6CJjYAAAAJ:eJXPG6dFmWUC:
-    citations: 497
+    citations: 498
     title: The theory of relativity
     year: '1996'
   qc6CJjYAAAAJ:eKGuBlYFiu8C:
@@ -2870,7 +2870,7 @@ papers:
     title: 'A Letter from Einstein: Praises Dean Muelder''s Distinguished Lecture" The Idea of the Responsible Society"'
     year: '1955'
   qc6CJjYAAAAJ:eq2jaN3J8jMC:
-    citations: 72
+    citations: 70
     title: "\xDCber den Frieden: Weltordnung oder Weltuntergang?"
     year: '1976'
   qc6CJjYAAAAJ:esGtpfCv0y8C:
@@ -2910,7 +2910,7 @@ papers:
     title: "Sushchnost\u02B9 teorii otnositel\u02B9nosti: Perevod s angli\u012Dskogo"
     year: '1955'
   qc6CJjYAAAAJ:fEOibwPWpKIC:
-    citations: 124
+    citations: 123
     title: "\xDCber den \xC4ther"
     year: '1924'
   qc6CJjYAAAAJ:fHS53ZCY-AEC:
@@ -2918,7 +2918,7 @@ papers:
     title: 'Albert Einstein] to Kathia Adler: Letter, 20 Feb 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:fLJJVVwU7EQC:
-    citations: 359
+    citations: 360
     title: "Ein einfaches Experiment zum Nachweis der Amp\xE8reschen Molekularstr\xF6me"
     year: '1916'
   qc6CJjYAAAAJ:fPk4N6BV_jEC:
@@ -2942,7 +2942,7 @@ papers:
     title: 'Albert Einstein] to Paul Ehrenfest: Letter, beginning Dec 1914'
     year: Unknown Year
   qc6CJjYAAAAJ:fh7vmlWxvT0C:
-    citations: 62
+    citations: 63
     title: 'Albert Einstein/Arnold Sommerfeld: Briefwechsel: Sechzig Briefe aus dem goldenen Zeitalter der modernen Physik'
     year: '1968'
   qc6CJjYAAAAJ:fixghrsIJ_wC:
@@ -2982,7 +2982,7 @@ papers:
     title: Zu Dr. Berliners siebzigstem Geburtstag
     year: '1932'
   qc6CJjYAAAAJ:gV6rEsy15s0C:
-    citations: 3924
+    citations: 3972
     title: Bemerkungen zu der Arbeit
     year: '1914'
   qc6CJjYAAAAJ:gYAb_yFic6IC:
@@ -2990,7 +2990,7 @@ papers:
     title: Zur Methodik der Theoretischen Physik
     year: '1934'
   qc6CJjYAAAAJ:gmHTDCtJMcoC:
-    citations: 161
+    citations: 160
     title: "Folgerungen aus den Capillarit\xE4tserscheinungen"
     year: '1901'
   qc6CJjYAAAAJ:gqMmJtG4vxUC:
@@ -3010,11 +3010,11 @@ papers:
     title: "Ejn\u0161tejnovskaja teorija otnosite\u013Enosti"
     year: '1972'
   qc6CJjYAAAAJ:hEXC_dOfxuUC:
-    citations: 396
+    citations: 397
     title: Reply to critics
     year: '1949'
   qc6CJjYAAAAJ:hEp1lTclR2YC:
-    citations: 328
+    citations: 330
     title: On the generalized theory of gravitation
     year: '1950'
   qc6CJjYAAAAJ:hKjooKYXoHIC:
@@ -3022,7 +3022,7 @@ papers:
     title: "\xDCber die formale Beziehung des Riemannschen Kr\xFCmmungstensors zu den Feldgleichungen der Gravitation"
     year: '1927'
   qc6CJjYAAAAJ:hMod-77fHWUC:
-    citations: 5281
+    citations: 5308
     title: "La relativit\xE9"
     year: '1964'
   qc6CJjYAAAAJ:hMwNgRnlwaMC:
@@ -3038,15 +3038,15 @@ papers:
     title: EddingtonsTheorie und Hamiltonsches Prinzip
     year: '1925'
   qc6CJjYAAAAJ:hVd5agGqjXwC:
-    citations: 3824
+    citations: 3831
     title: Physikalische Gesellschaft Zuerich
     year: '1916'
   qc6CJjYAAAAJ:hbz17DqrwuEC:
-    citations: 352
+    citations: 353
     title: Notiz zu unserer Arbeit
     year: '1915'
   qc6CJjYAAAAJ:hcF2OqvMasEC:
-    citations: 140
+    citations: 136
     title: Warum Krieg?
     year: '1933'
   qc6CJjYAAAAJ:he8YCnfqqkoC:
@@ -3102,7 +3102,7 @@ papers:
     title: Geometria no euclidea y fisica
     year: '1926'
   qc6CJjYAAAAJ:i_7YvbSbtFEC:
-    citations: 8915
+    citations: 8933
     title: "Berichtigung zu meiner Arbeit:\u201EEine neue Bestimmung der Molek\xFCldimensionen\u201D \uFE01"
     year: '2006'
   qc6CJjYAAAAJ:ifIdVpG6JtcC:
@@ -3122,7 +3122,7 @@ papers:
     title: "La th\xE9orie de la relativit\xE9 d'Einstein et la dialectique."
     year: Unknown Year
   qc6CJjYAAAAJ:isC4tDSrTZIC:
-    citations: 4304
+    citations: 4348
     title: "\xDCber Gravitationswellen"
     year: '1918'
   qc6CJjYAAAAJ:it4f3qIuXWYC:
@@ -3178,7 +3178,7 @@ papers:
     title: A memorial to PAM Dirac
     year: '1990'
   qc6CJjYAAAAJ:k4O5U3vRA4YC:
-    citations: 5816
+    citations: 5845
     title: The special and general theory
     year: '1920'
   qc6CJjYAAAAJ:k6nH7jlkaTkC:
@@ -3222,11 +3222,11 @@ papers:
     title: "Albert Einstein] to Walter D\xE4llenbach: Letter, after 15 Feb 1917"
     year: Unknown Year
   qc6CJjYAAAAJ:kqeZabM7ilsC:
-    citations: 7040
+    citations: 7072
     title: Preuss, Sitzungsber
     year: '1915'
   qc6CJjYAAAAJ:l0_JBNIuc60C:
-    citations: 56
+    citations: 57
     title: Quoted in
     year: '1990'
   qc6CJjYAAAAJ:l1jknz_x7mgC:
@@ -3234,11 +3234,11 @@ papers:
     title: Court Expert Opinion in the Matter of Signal Co. vs. Atlas Works, ca. 3 Dec 1921
     year: Unknown Year
   qc6CJjYAAAAJ:l6Q3WhenKVUC:
-    citations: 592
+    citations: 593
     title: Geometrie und erfahrung
     year: '1921'
   qc6CJjYAAAAJ:l7t_Zn2s7bgC:
-    citations: 663
+    citations: 666
     title: Ether and the Theory of Relativity
     year: '2007'
   qc6CJjYAAAAJ:lAj_JhtUatoC:
@@ -3254,7 +3254,7 @@ papers:
     title: The collecteds of albert einstein v 9 the berlin years correspondence january 1919-april 1920 english translation (paperback)
     year: '2004'
   qc6CJjYAAAAJ:lEqHes_HPG0C:
-    citations: 799
+    citations: 801
     title: 'The principle of relativity: a collection of original memoirs on the special and general theory of relativity'
     year: '1923'
   qc6CJjYAAAAJ:lIaPce-xyHYC:
@@ -3266,7 +3266,7 @@ papers:
     title: "Grundgedanken und Probleme der Relativit\xE4tstheorie"
     year: '1923'
   qc6CJjYAAAAJ:lLPirIASiZEC:
-    citations: 855
+    citations: 859
     title: "The Collected Papers of Albert Einstein, Volume 15 (Translation Supplement): The Berlin Years: Writings & Correspondence, June 1925\u2013May 1927"
     year: '2018'
   qc6CJjYAAAAJ:lOG7zRu2uA8C:
@@ -3302,7 +3302,7 @@ papers:
     title: "Hilbert et le probl\xE8me de covariance dans les \xE9quations de la gravitation."
     year: Unknown Year
   qc6CJjYAAAAJ:mB3voiENLucC:
-    citations: 146
+    citations: 147
     title: A new form of the general relativistic field equations
     year: '1955'
   qc6CJjYAAAAJ:mN77zE6YZBUC:
@@ -3418,11 +3418,11 @@ papers:
     title: "Neue Zugangswege zur Entw\xF6hnungs-behandlung in Sachsen, Sachsen-Anhalt und Th\xFCringen"
     year: Unknown Year
   qc6CJjYAAAAJ:nwfoItMF7hMC:
-    citations: 443
+    citations: 444
     title: "Teor\u0131a cu\xE1ntica de gases ideales monoat\xF3micos, Sitz"
     year: '1924'
   qc6CJjYAAAAJ:o4Qvs5Y5TLQC:
-    citations: 993
+    citations: 997
     title: The Early Years 1879-1902
     year: '1987'
   qc6CJjYAAAAJ:o9ULDYDKYbIC:
@@ -3434,11 +3434,11 @@ papers:
     title: Eine neue formale Deutung der Maxwellschen Feldgleichungen der Elektrodynamik
     year: '1916'
   qc6CJjYAAAAJ:oFKsPyNwwpYC:
-    citations: 86
+    citations: 87
     title: "\xDCber die M\xF6glichkeit einer neuen Pr\xFCfung des Relativit\xE4tsprinzips"
     year: '2006'
   qc6CJjYAAAAJ:oFWWKr2Zb18C:
-    citations: 124
+    citations: 123
     title: On the ether
     year: '1991'
   qc6CJjYAAAAJ:oJZlKik0E8QC:
@@ -3454,7 +3454,7 @@ papers:
     title: 'Le pouvoir nu: propos sur la guerre et la paix, 1914-1955'
     year: '1991'
   qc6CJjYAAAAJ:oYLFIHfuHKwC:
-    citations: 248
+    citations: 249
     title: "Zum kosmologischen Problem der allgemeinen Relativit\xE4tstheorie"
     year: '1931'
   qc6CJjYAAAAJ:oea97a5D_h0C:
@@ -3462,7 +3462,7 @@ papers:
     title: "\xDCber den gegenw\xE4rtigen Stand der allgemeinen Relativit\xE4tsteorie"
     year: '1930'
   qc6CJjYAAAAJ:ojlX30-wUrgC:
-    citations: 194
+    citations: 195
     title: Religion and science
     year: '1930'
   qc6CJjYAAAAJ:oldoQiaHq2UC:
@@ -3470,7 +3470,7 @@ papers:
     title: "Einheitliche Theorie von Gravitation und Elektrizit\xE4t. Zweite Abhandlung"
     year: '2006'
   qc6CJjYAAAAJ:oqD4_j7ulsYC:
-    citations: 20630
+    citations: 20715
     title: On the movement of small particles suspended in stationary liquids required by the molecular-kinetic theory of heat
     year: '1905'
   qc6CJjYAAAAJ:osi8XriVlOYC:
@@ -3574,7 +3574,7 @@ papers:
     title: "Quatre conf\xE9rences sur la th\xE9orie de la relativit\xE9 faites \xE0 l'Universit\xE9 de Princeton"
     year: '2005'
   qc6CJjYAAAAJ:qCpRzq7zkD8C:
-    citations: 2220
+    citations: 2228
     title: "Zur allgemeinen Relativit\xE4tstheorie"
     year: '1915'
   qc6CJjYAAAAJ:qPeb-qHga9sC:
@@ -3590,11 +3590,11 @@ papers:
     title: "En busca del eslab\xF3n perdido entre educaci\xF3n y desarrollo: desaf\xEDos y retos para la universidad en Am\xE9rica Latina y el Caribe"
     year: Unknown Year
   qc6CJjYAAAAJ:qjMakFHDy7sC:
-    citations: 3371
+    citations: 3392
     title: On the electrodynamics of moving bodies
     year: '1905'
   qc6CJjYAAAAJ:qsWQJNntlusC:
-    citations: 3228
+    citations: 3238
     title: Ideas and opinions
     year: '1995'
   qc6CJjYAAAAJ:quBVm8e4N6QC:
@@ -3602,11 +3602,11 @@ papers:
     title: "Zu Kaluzas Theorie des Zusammenhanges von Gravitation und Elektrizit\xE4t. Zweite Mitteilung"
     year: '2006'
   qc6CJjYAAAAJ:qxL8FJ1GzNcC:
-    citations: 615
+    citations: 616
     title: Geometrie und erfahrung
     year: '1921'
   qc6CJjYAAAAJ:qyhmnyLat1gC:
-    citations: 27983
+    citations: 28090
     title: Can quantum-mechanical description of physical reality be considered complete?
     year: '1935'
   qc6CJjYAAAAJ:qzuIxkxWBNsC:
@@ -3638,7 +3638,7 @@ papers:
     title: Oorlog als ziekte. Met een voorw. van Albert Einstein. Naar de Nederlandse vertaling bewerkt door C. van Emde Boas
     year: '1938'
   qc6CJjYAAAAJ:rCzfLUpcSPoC:
-    citations: 451
+    citations: 452
     title: "A evolu\xE7\xE3o da f\xEDsica: o desenvolvimento das ideias desde os primitivos conceitos at\xE9 \xE0 Relatividade e aos Quanta"
     year: '1939'
   qc6CJjYAAAAJ:rFyVMFCKTwsC:
@@ -3650,7 +3650,7 @@ papers:
     title: "Gelegentliches: Zum f\xFCnfzigsten Geburtstag 14. M\xE4rz 1929 dargebracht von der Soncino-Gesellschaft der Freunde des J\xFCdischen Buches zu Berlin"
     year: '1929'
   qc6CJjYAAAAJ:rPbfW60zdgkC:
-    citations: 1208
+    citations: 1216
     title: Physics and reality
     year: '1936'
   qc6CJjYAAAAJ:rQcm2j6_ZE8C:
@@ -3662,7 +3662,7 @@ papers:
     title: A new analysis of molecule dimensions
     year: '1968'
   qc6CJjYAAAAJ:rWqKpwLRvsIC:
-    citations: 3147
+    citations: 3185
     title: Die feldgleichungen der gravitation
     year: Unknown Year
   qc6CJjYAAAAJ:rbgNTKsR3fAC:
@@ -3722,7 +3722,7 @@ papers:
     title: "La th\xE9orie corpusculaire des rayons X et la structure des cristaux."
     year: Unknown Year
   qc6CJjYAAAAJ:sAujV351FBYC:
-    citations: 4889
+    citations: 4902
     title: The meaning of relativity
     year: '1950'
   qc6CJjYAAAAJ:sIDMtVbdO0QC:
@@ -3730,7 +3730,7 @@ papers:
     title: "\xDCber die gegenw\xE4rtige Krise der theoretischen Physik"
     year: '1922'
   qc6CJjYAAAAJ:sJK75vZXtG0C:
-    citations: 208
+    citations: 210
     title: Mis ideas y opiniones
     year: '2011'
   qc6CJjYAAAAJ:sNmaIFBj_lkC:
@@ -3754,7 +3754,7 @@ papers:
     title: The laws of science and the laws of ethics
     year: '1950'
   qc6CJjYAAAAJ:sgsej9ZJWHMC:
-    citations: 4469
+    citations: 4506
     title: "N\xE4herungsweise Integration der Feldgleichungen der Gravitation"
     year: '1916'
   qc6CJjYAAAAJ:siTy-4AL0AwC:
@@ -3782,7 +3782,7 @@ papers:
     title: Uproar in the Lecture Hall, 13 Feb 1920
     year: Unknown Year
   qc6CJjYAAAAJ:t6usbXjVLHcC:
-    citations: 144
+    citations: 143
     title: The human side
     year: '1979'
   qc6CJjYAAAAJ:t7izwRedFcYC:
@@ -3798,7 +3798,7 @@ papers:
     title: "Geografia, ecologia da paisagem e teledetec\xE7\xE3o, enquadramento\u2013contextualiza\xE7\xE3o"
     year: '2004'
   qc6CJjYAAAAJ:tWiuw1KVSQEC:
-    citations: 90
+    citations: 91
     title: "La Th\xE9orie de la Relativit\xE9"
     year: '1935'
   qc6CJjYAAAAJ:tYdqGa2HnWcC:
@@ -3838,7 +3838,7 @@ papers:
     title: "equations of motion\uFB01 one therefore could not doubt that the laws of nature are"
     year: '1907'
   qc6CJjYAAAAJ:uCYQzKCmtZwC:
-    citations: 1232
+    citations: 1234
     title: Out of my later years
     year: '1950'
   qc6CJjYAAAAJ:uH1VZYVfkoQC:
@@ -3866,7 +3866,7 @@ papers:
     title: "Bemerkung zu meiner Arbeit \u201CZur allgemeinen Relativit\xE4tstheorie\u201D"
     year: '2006'
   qc6CJjYAAAAJ:ufrVoPGSRksC:
-    citations: 646
+    citations: 650
     title: The influence of the expansion of space on the gravitation fields surrounding the individual stars
     year: '1945'
   qc6CJjYAAAAJ:uh8FjILnQOkC:
@@ -3930,7 +3930,7 @@ papers:
     title: On the five-dimensional representation of gravitation and electricity
     year: '1941'
   qc6CJjYAAAAJ:viPVbuMW504C:
-    citations: 403
+    citations: 404
     title: Collected Scientific Works
     year: '1965'
   qc6CJjYAAAAJ:viTTOddtVMkC:
@@ -3938,7 +3938,7 @@ papers:
     title: IDEAS PARA MEDITAR CON CALMA
     year: Unknown Year
   qc6CJjYAAAAJ:vj8KeYadoLsC:
-    citations: 73
+    citations: 74
     title: Diskussion
     year: '1920'
   qc6CJjYAAAAJ:vjZqxyZ7hS4C:
@@ -3970,7 +3970,7 @@ papers:
     title: "Introduction aux th\xE8ories de M. Einstein en vue de leur application a l'astronomie"
     year: '1921'
   qc6CJjYAAAAJ:vytXtR8tOLIC:
-    citations: 3366
+    citations: 3393
     title: B. preuss
     year: '1916'
   qc6CJjYAAAAJ:vzY-6mMDyDUC:
@@ -3994,7 +3994,7 @@ papers:
     title: Eine ableitung des theorems von Jacobi
     year: '1917'
   qc6CJjYAAAAJ:wEOyVsangm4C:
-    citations: 747
+    citations: 749
     title: Philosopher-Scientist, ed
     year: '1970'
   qc6CJjYAAAAJ:wGzT3bKASkAC:
@@ -4018,7 +4018,7 @@ papers:
     title: "La teoria della relativit\xE0"
     year: '1987'
   qc6CJjYAAAAJ:wgKq3sYidysC:
-    citations: 532
+    citations: 535
     title: Concerning an heuristic point of view toward the emission and transformation of light
     year: '1965'
   qc6CJjYAAAAJ:wkm4DBaukwsC:
@@ -4030,7 +4030,7 @@ papers:
     title: 'Albert Einstein] to Michele Besso: Letter, 6 Sep 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:wuD5JclIwkYC:
-    citations: 243
+    citations: 244
     title: Science and religion
     year: '1940'
   qc6CJjYAAAAJ:wy5MF_2MSNEC:
@@ -4058,7 +4058,7 @@ papers:
     title: "Briefe zur Wellenmechanik [von][Erwin] Schr\xF6dinger,[Max] Planck,[ALbert] Einstein und [Hendrik Antoon] Lorentz"
     year: '1963'
   qc6CJjYAAAAJ:xvKSgulxyWUC:
-    citations: 795
+    citations: 799
     title: 'The collected papers of Albert Einstein: writings, 1912-1914. The Swiss years'
     year: '1966'
   qc6CJjYAAAAJ:xwIxJehhd2UC:
@@ -4078,11 +4078,11 @@ papers:
     title: 'Albert Einstein] to Gustav Mie: Letter, 29 Dec 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:yIeBiWEAh44C:
-    citations: 1352
+    citations: 1356
     title: "\xDCber den Einflu\xDF der Schwerkraft auf die Ausbreitung des Lichtes"
     year: '2006'
   qc6CJjYAAAAJ:yJjnfzR0HrkC:
-    citations: 902
+    citations: 904
     title: Strahlungs-emission und absorption nach der quantentheorie
     year: '1916'
   qc6CJjYAAAAJ:yKZlB_2wKysC:
@@ -4094,7 +4094,7 @@ papers:
     title: A generalized theory of gravitation
     year: '1948'
   qc6CJjYAAAAJ:yNohvu9kXXYC:
-    citations: 446
+    citations: 449
     title: Quantentheorie des idealen einatomigen Gases, Sitzber
     year: '1924'
   qc6CJjYAAAAJ:yS0fcbgecPsC:

--- a/_data/citations.yml
+++ b/_data/citations.yml
@@ -1,5 +1,5 @@
 metadata:
-  last_updated: '2026-05-15'
+  last_updated: '2026-06-17'
 papers:
   qc6CJjYAAAAJ:-1WLWRmjvKAC:
     citations: 4
@@ -18,7 +18,7 @@ papers:
     title: 'The Palestine Troubles: Einstein''s Protest, Zionism''s Basis and Achievement; the Mandatory''s Task'
     year: '1929'
   qc6CJjYAAAAJ:-LHtoeeytlUC:
-    citations: 2548
+    citations: 2562
     title: 'Albert Einstein: Philosopher Scientist'
     year: '1969'
   qc6CJjYAAAAJ:-R_Z4shfoosC:
@@ -26,11 +26,11 @@ papers:
     title: 'Albert Einstein] to Paul Ehrenfest: Letter, 22 Jul 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:-Viv1fr_sjoC:
-    citations: 138
+    citations: 139
     title: The special theory of relativity
     year: '1905'
   qc6CJjYAAAAJ:-_cDHGlXAtsC:
-    citations: 8347
+    citations: 8483
     title: Sitzungsberichte der Preussischen Akad. d
     year: '1917'
   qc6CJjYAAAAJ:-fj4grS0xi0C:
@@ -38,11 +38,11 @@ papers:
     title: 'Conceptions scientifiques, morales et sociales: traduit de l''anglais par Maurice Solovine'
     year: '1952'
   qc6CJjYAAAAJ:-l7FTdOV6Y0C:
-    citations: 193
+    citations: 194
     title: Brownian motion
     year: '1936'
   qc6CJjYAAAAJ:-qpA3cGbmHsC:
-    citations: 541
+    citations: 546
     title: On the Relation between the Expansion and the Mean Density of the Universe
     year: '1932'
   qc6CJjYAAAAJ:-vzq6BoH5oUC:
@@ -70,7 +70,7 @@ papers:
     title: Elementary Considerations on the Interpretation of the Foundations of Quantum Mechanics
     year: '2011'
   qc6CJjYAAAAJ:0EnyYjriUFMC:
-    citations: 1205
+    citations: 1211
     title: 'The Born Einstein Letters: correspondence between Albert Einstein and Max and Hedwig Born from 1916 to 1955 with commentaries by Max Born. Translated by Irene Born'
     year: '1971'
   qc6CJjYAAAAJ:0KZCP5UExFUC:
@@ -82,7 +82,7 @@ papers:
     title: "Zeitungen gleichen Sparb\xFCchern: dass sie voll geschrieben sind, bedeutet noch nichts."
     year: Unknown Year
   qc6CJjYAAAAJ:0SnApaDgcCoC:
-    citations: 69
+    citations: 66
     title: podolsky B and Rosen N 1935 Phys
     year: Unknown Year
   qc6CJjYAAAAJ:0UEtxawf5sEC:
@@ -110,7 +110,7 @@ papers:
     title: Correspondencia con Michele Besso:(1903-1955)
     year: '1994'
   qc6CJjYAAAAJ:0t1ZDozeHsAC:
-    citations: 6
+    citations: 5
     title: Essays in science
     year: '1954'
   qc6CJjYAAAAJ:0wD49__q8KEC:
@@ -130,11 +130,11 @@ papers:
     title: "Die Nordstr\xF6msche gravitationstheorie vom standpunkt des absoluten Differentialkalk\xFCls"
     year: '1914'
   qc6CJjYAAAAJ:1AS7WB7zg6gC:
-    citations: 78
+    citations: 79
     title: "L'\xE9ther et la th\xE9orie de la relativit\xE9"
     year: '1921'
   qc6CJjYAAAAJ:1DhOeZtQFr0C:
-    citations: 495
+    citations: 496
     title: Principle Points of the General Theory of Relativity
     year: '1918'
   qc6CJjYAAAAJ:1EM7I_rJWO4C:
@@ -194,7 +194,7 @@ papers:
     title: "Die Einstein-Sammlung der ETH-Bibliothek in Z\xFCrich: ein Ueberblick f\xFCr Ben\xFCtzer der Handschriften-Abteilung"
     year: '1970'
   qc6CJjYAAAAJ:2C0LhDdYSbcC:
-    citations: 1532
+    citations: 1533
     title: "Le principe de relativit\xE9 et ses cons\xE9quences dans la physique moderne"
     year: '1910'
   qc6CJjYAAAAJ:2KloaMYe4IUC:
@@ -210,7 +210,7 @@ papers:
     title: 'Albert Einstein] to Conrad Habicht: Letter, 15 Apr 1904'
     year: Unknown Year
   qc6CJjYAAAAJ:2ZctHUgIzyAC:
-    citations: 469
+    citations: 473
     title: "La g\xE9om\xE9trie et l'exp\xE9rience"
     year: '1921'
   qc6CJjYAAAAJ:2hfDYGh-f1UC:
@@ -242,7 +242,7 @@ papers:
     title: 'Albert Einstein] to Wilhelm von Siemens: Letter, 4 Jan 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:3fE2CSJIrl8C:
-    citations: 330
+    citations: 331
     title: A generalization of the relativistic theory of gravitation, II
     year: '1946'
   qc6CJjYAAAAJ:3pYxbvHKFu8C:
@@ -250,7 +250,7 @@ papers:
     title: Briefwechsel 1916-1955
     year: '1972'
   qc6CJjYAAAAJ:3s1wT3WcHBgC:
-    citations: 74
+    citations: 75
     title: A brief outline of the development of the theory of relativity
     year: '1921'
   qc6CJjYAAAAJ:3s2jc9hNhkQC:
@@ -258,7 +258,7 @@ papers:
     title: Relativity in Newtonian Mechanics and the Michelson-Morley Experiment
     year: Unknown Year
   qc6CJjYAAAAJ:3vbIHxFL9FgC:
-    citations: 348
+    citations: 351
     title: "Experimenteller Nachweis der Amp\xE8reschen Molekularstr\xF6me"
     year: '1915'
   qc6CJjYAAAAJ:3z7foVzkq2cC:
@@ -270,11 +270,11 @@ papers:
     title: Nachtrag zu meiner Arbeit:Thermodynamische Begruendung des photochemischen Aequivalentgesetzes'(from Annalen der Physik 1912)
     year: '1993'
   qc6CJjYAAAAJ:4Bh_hC5jS3YC:
-    citations: 7137
+    citations: 7157
     title: Graviton Mass and Inertia Mass
     year: '1911'
   qc6CJjYAAAAJ:4DMP91E08xMC:
-    citations: 541
+    citations: 545
     title: The Origins of the General Theory of Relativity
     year: '1933'
   qc6CJjYAAAAJ:4E1Y8I9HL1wC:
@@ -290,15 +290,15 @@ papers:
     title: 'Albert Einstein] to Mileva Einstein-Maric: Letter, 17 Apr 1908'
     year: Unknown Year
   qc6CJjYAAAAJ:4JMBOYKVnBMC:
-    citations: 2975
+    citations: 2999
     title: Quantentheorie des einatomigen idealen Gases
     year: '1924'
   qc6CJjYAAAAJ:4QKQTXcH0q8C:
-    citations: 77
+    citations: 78
     title: "Kritisches zu einer von Hrn. de Sitter gegebenen L\xF6sung der Gravitationsgleichungen"
     year: '1918'
   qc6CJjYAAAAJ:4S6zbAYdD6oC:
-    citations: 15
+    citations: 17
     title: Naturwissenschaft und Religion
     year: '1960'
   qc6CJjYAAAAJ:4TOpqqG69KYC:
@@ -306,7 +306,7 @@ papers:
     title: 'Die Evolution der Physik: Von Newton bis zur Quantentheorie'
     year: '1956'
   qc6CJjYAAAAJ:4UtermoNRQAC:
-    citations: 51
+    citations: 52
     title: Autobiographische Skizze
     year: '1956'
   qc6CJjYAAAAJ:4ZjPyBmb-CUC:
@@ -318,7 +318,7 @@ papers:
     title: Einstein on science
     year: '2000'
   qc6CJjYAAAAJ:4fKUyHm3Qg0C:
-    citations: 69
+    citations: 68
     title: 'Albert Einstein, Mileva Maric: The Love Letters'
     year: '2000'
   qc6CJjYAAAAJ:4hFrxpcac9AC:
@@ -346,7 +346,7 @@ papers:
     title: 'Einstein, the Man and His Achievement: A Series of Broadcast Talks'
     year: '1967'
   qc6CJjYAAAAJ:5-tCjTwfAdEC:
-    citations: 460
+    citations: 462
     title: "Die Relativit\xE4tstheorie"
     year: '1915'
   qc6CJjYAAAAJ:5Hlrm_bZEgcC:
@@ -362,7 +362,7 @@ papers:
     title: "Bemerkung zu der Arbeit von A. Friedmann \u201E\xDCber die Kr\xFCmmung des Raumes \u201C"
     year: '1922'
   qc6CJjYAAAAJ:5McdzzY_mmwC:
-    citations: 39
+    citations: 40
     title: Correspondence 1916-1955 [entre] Albert Einstein, Max Born et Hedwig Born
     year: '1972'
   qc6CJjYAAAAJ:5UUbrqTvKfUC:
@@ -386,11 +386,11 @@ papers:
     title: 'Albert Einstein] to Emil Beck: Letter, 30 Apr 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:5bGIVMdsOr0C:
-    citations: 172
+    citations: 173
     title: My theory
     year: '1919'
   qc6CJjYAAAAJ:5pGZGXnFQ_sC:
-    citations: 10502
+    citations: 10670
     title: Sitzungsber. K
     year: '1925'
   qc6CJjYAAAAJ:5qfkUJPXOUwC:
@@ -414,11 +414,11 @@ papers:
     title: 'Doctrines about the Universe: With Proof in the Form of a Letter to the Public and to Professor Einstein'
     year: '1821'
   qc6CJjYAAAAJ:6CdnuHuKHxIC:
-    citations: 80
+    citations: 81
     title: Refrigeration
     year: '1927'
   qc6CJjYAAAAJ:6DS7WFnF4J4C:
-    citations: 141
+    citations: 142
     title: Koniglich Preussische Akademie der Wissenschaften
     year: '1983'
   qc6CJjYAAAAJ:6Dd5luMImnEC:
@@ -438,7 +438,7 @@ papers:
     title: "Conceptos, ambientes de aprendizaje:\xBF c\xF3mo aprendemos los humanos en diferentes contextos? Waleska Aldana Segura"
     year: Unknown Year
   qc6CJjYAAAAJ:6ftYtcnYaCAC:
-    citations: 342
+    citations: 344
     title: Ather and Relativitatstheorie. J
     year: '1920'
   qc6CJjYAAAAJ:6gD0efnhv6MC:
@@ -458,7 +458,7 @@ papers:
     title: "Bietet die feldtheorie M\xF6glichkeiten f\xFCr die L\xF6sung des Quantenproblems?"
     year: '1923'
   qc6CJjYAAAAJ:7DJsn6tmoAwC:
-    citations: 329
+    citations: 331
     title: "\xC4ther und Relativit\xE4ts-theorie"
     year: '1920'
   qc6CJjYAAAAJ:7DTIKO_nxaIC:
@@ -466,7 +466,7 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 8 Jan 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:7VEv-pLvLSsC:
-    citations: 344
+    citations: 345
     title: "Elementare Betrachtungen \xFCber die thermische Molekularbewegung in festen K\xF6rpern"
     year: '1911'
   qc6CJjYAAAAJ:7XUxBq3GufIC:
@@ -546,7 +546,7 @@ papers:
     title: "Bemerkung zu der Arbeit von D. Mirimanoff \u201E\xDCber die Grundgleichungen\u2026\u201D \uFE01"
     year: '1909'
   qc6CJjYAAAAJ:8k81kl-MbHgC:
-    citations: 378
+    citations: 380
     title: Essays in science
     year: '2011'
   qc6CJjYAAAAJ:8moDcb_GFzgC:
@@ -554,7 +554,7 @@ papers:
     title: 'Albert Einstein] to Erwin Freundlich: Letter, 19 Mar 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:8p-ueveQw4wC:
-    citations: 13
+    citations: 12
     title: "Ciencia y religi\xF3n"
     year: '1984'
   qc6CJjYAAAAJ:8p8iYwVyaVcC:
@@ -566,7 +566,7 @@ papers:
     title: "Die Einstein-Dokumente im Archiv der Humboldt-Universit\xE4t zu Berlin"
     year: '1973'
   qc6CJjYAAAAJ:94rQ0kDLHKYC:
-    citations: 4562
+    citations: 4587
     title: Evolution of Physics
     year: '1954'
   qc6CJjYAAAAJ:9CGX2owmTHMC:
@@ -574,7 +574,7 @@ papers:
     title: DIE NATLIRWISSENSCHAFTEN
     year: Unknown Year
   qc6CJjYAAAAJ:9LpHyFPp1DQC:
-    citations: 558
+    citations: 559
     title: "Riemann\u2010Geometrie mit Aufrechterhaltung des Begriffes des Fernparallelismus"
     year: '1928'
   qc6CJjYAAAAJ:9N3KX2BFTccC:
@@ -618,7 +618,7 @@ papers:
     title: "Fizika i real\u02B9nost\u02B9: sbornik state\u012D"
     year: '1965'
   qc6CJjYAAAAJ:9u2w3wkYHSMC:
-    citations: 95
+    citations: 97
     title: "Maxwell\u2019s influence on the development of the conception of physical reality"
     year: '1931'
   qc6CJjYAAAAJ:9xDRhSErrBIC:
@@ -654,7 +654,7 @@ papers:
     title: La relativit# a speciale
     year: '1920'
   qc6CJjYAAAAJ:AVQCy-ZCKIsC:
-    citations: 112
+    citations: 116
     title: "Planck\u2019s theory of radiation and the theory of specific heat"
     year: '1907'
   qc6CJjYAAAAJ:AYaE08C4-t8C:
@@ -766,7 +766,7 @@ papers:
     title: 'Albert Einstein] to Paul Seippel: Letter, 19 Aug 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:CLQ-NLsb8zAC:
-    citations: 3158
+    citations: 3172
     title: Ideas and Opinions
     year: '1954'
   qc6CJjYAAAAJ:COU-sansr_wC:
@@ -774,7 +774,7 @@ papers:
     title: "Elie Cartan-Albert Einstein: lettres sur le parall\xE9lisme absolu 1929-1932"
     year: '1979'
   qc6CJjYAAAAJ:CQX_Vi8q7s0C:
-    citations: 1962
+    citations: 1969
     title: Introduction Einstein's Relativity
     year: '1992'
   qc6CJjYAAAAJ:CRQ797xmLJIC:
@@ -790,11 +790,11 @@ papers:
     title: "Untersuchungen \xFCber die Theorie der Brownschen Bewegung/Abhandlungen \xFCber die Brownsche Bewegung und verwandte Erscheinungen"
     year: '1999'
   qc6CJjYAAAAJ:CY3uIpTmi-gC:
-    citations: 148
+    citations: 152
     title: Einstein on Cosmic Religion and Other Opinions and Aphorisms
     year: '2009'
   qc6CJjYAAAAJ:CmbFvBriOyMC:
-    citations: 188
+    citations: 189
     title: "O significado da relatividade: com a teoria relativista do campo n\xE3o sim\xE9trico"
     year: '1958'
   qc6CJjYAAAAJ:CmeMDzcFUg4C:
@@ -806,19 +806,19 @@ papers:
     title: "\xDCber die Untersuchung des \xC4therzustandes im magnetischen Felde"
     year: '1971'
   qc6CJjYAAAAJ:CoqsOaBEKcQC:
-    citations: 11
+    citations: 12
     title: Improvements relating to refrigerating apparatus
     year: '1927'
   qc6CJjYAAAAJ:CrVLTnlDqZQC:
-    citations: 15
+    citations: 16
     title: On the moral obligation of the scientist
     year: '1945'
   qc6CJjYAAAAJ:Cv-mv52rCCkC:
-    citations: 5297
+    citations: 5318
     title: On the motion of particles suspended in a liquid at rest, assumed by the molecular-kinetic theory of heat
     year: '1905'
   qc6CJjYAAAAJ:Cx2ibDnldiAC:
-    citations: 38
+    citations: 39
     title: On the quantum mechanics of radiation
     year: '1917'
   qc6CJjYAAAAJ:Cy13deThEpcC:
@@ -858,7 +858,7 @@ papers:
     title: Jarbuch der Radioaktivitat und Elektronik, 4, 411 (1907), reprinted in The Collected Papers of A. Einstein, vol. 2, 252
     year: '1989'
   qc6CJjYAAAAJ:DQNrXyjhriIC:
-    citations: 3057
+    citations: 3140
     title: Die feldgleichungen der gravitation
     year: '1915'
   qc6CJjYAAAAJ:D_sINldO8mEC:
@@ -898,7 +898,7 @@ papers:
     title: Kreative Methoden 239 Kindern in Deutsehland lebensweltliche Erfahrungen von politischen Er
     year: Unknown Year
   qc6CJjYAAAAJ:E2bRg1zSkIsC:
-    citations: 288
+    citations: 287
     title: A teoria da relatividade especial e geral
     year: '2003'
   qc6CJjYAAAAJ:E2dP09oujfMC:
@@ -938,7 +938,7 @@ papers:
     title: 'Albert Einstein] to Romain Rolland: Letter, 22 Mar 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:EYYDruWGBe4C:
-    citations: 227
+    citations: 228
     title: "The Collected Papers of Albert Einstein, Vol. 2, The Swiss Years: Writings, 1900\u20131909 (English Translation Supplement)"
     year: '1989'
   qc6CJjYAAAAJ:Ecsxi449JjsC:
@@ -946,7 +946,7 @@ papers:
     title: "Sur le probl\xE8me de la formation de la personnalit\xE9 cr\xE9atrice d'Einstein."
     year: Unknown Year
   qc6CJjYAAAAJ:Ei5r6KrKXVQC:
-    citations: 1514
+    citations: 1517
     title: "Theorie der Opaleszenz von homogenen Fl\xFCssigkeiten und Fl\xFCssigkeitsgemischen in der N\xE4he des kritischen Zustandes"
     year: '2006'
   qc6CJjYAAAAJ:EpJ50YjRFhcC:
@@ -986,7 +986,7 @@ papers:
     title: 'Einstein: Science and Religion'
     year: Unknown Year
   qc6CJjYAAAAJ:FKYJxdYMdFIC:
-    citations: 999
+    citations: 1002
     title: "The Collected Papers of Albert Einstein, Volume 15 (Translation Supplement): The Berlin Years: Writings & Correspondence, June 1925\u2013May 1927"
     year: '2018'
   qc6CJjYAAAAJ:FKzTm0Bp8ZYC:
@@ -1010,11 +1010,11 @@ papers:
     title: Impact of Science on the Development of Pacifism, before 9 Dec 1921
     year: Unknown Year
   qc6CJjYAAAAJ:FTNwVkz-CAMC:
-    citations: 81
+    citations: 82
     title: Outline of a generalized theory of relativity and of a theory of gravitation
     year: '1913'
   qc6CJjYAAAAJ:FV77Gu53xKkC:
-    citations: 123
+    citations: 124
     title: the Theory of Gravitation
     year: '1974'
   qc6CJjYAAAAJ:FcH-RsB9iB0C:
@@ -1110,7 +1110,7 @@ papers:
     title: "El gobierno de Felipe Calder\xF3n\xBF hacia un desarrollo humano sustentable? Susana Garcia jimenez"
     year: Unknown Year
   qc6CJjYAAAAJ:GnPB-g6toBAC:
-    citations: 161
+    citations: 162
     title: Einstein on peace
     year: '1968'
   qc6CJjYAAAAJ:GpOSJs1ZbLkC:
@@ -1122,7 +1122,7 @@ papers:
     title: Ernst Mach
     year: '1916'
   qc6CJjYAAAAJ:Grx829lh2T4C:
-    citations: 3085
+    citations: 3109
     title: Quantum theory of monatomic ideal gases
     year: '1924'
   qc6CJjYAAAAJ:GsgvGxwuA5UC:
@@ -1130,7 +1130,7 @@ papers:
     title: 'Correspondance 1903-1955: Albert Einstein, Michele Besso'
     year: '1979'
   qc6CJjYAAAAJ:GtLg2Ama23sC:
-    citations: 19
+    citations: 20
     title: "L'\xE9ther et la th\xE9orie de la relativit\xE9: La g\xE9om\xE9trie et l'exp\xE9rience"
     year: '1964'
   qc6CJjYAAAAJ:GtszHNlY0egC:
@@ -1142,7 +1142,7 @@ papers:
     title: "Theorien verborgener Parameter, EPR-Korrelationen, Bell\u2019sche Ungleichung, GHZ-Zust ande"
     year: '1999'
   qc6CJjYAAAAJ:GzlcqhCAosUC:
-    citations: 491
+    citations: 493
     title: "QUANTEN\u2010MECHANIK UND WIRKLICHKEIT"
     year: '1948'
   qc6CJjYAAAAJ:H-nlc5mcmJQC:
@@ -1178,11 +1178,11 @@ papers:
     title: Riemann-Metrik mit Aufrechterhaltung des Begriffes der Fern-parallelismus, Preuss
     year: '1928'
   qc6CJjYAAAAJ:HklM7qHXWrUC:
-    citations: 460
+    citations: 462
     title: "Die Relativit\xE4tstheorie"
     year: '1925'
   qc6CJjYAAAAJ:Hl4CZ0n6gBQC:
-    citations: 21604
+    citations: 21740
     title: Uber einen die Erzeugung und Verwandlung des Lichtes betreffenden heurischen Gesichtpunkt
     year: '1905'
   qc6CJjYAAAAJ:HtEfBTGE9r8C:
@@ -1194,7 +1194,7 @@ papers:
     title: 'Science: Conjectures and Refutations'
     year: '1997'
   qc6CJjYAAAAJ:HygtOXotxAUC:
-    citations: 43
+    citations: 44
     title: "Sur l'\xE9lectrodynamique des corps en mouvement"
     year: '1925'
   qc6CJjYAAAAJ:I6TX2FUo6loC:
@@ -1206,11 +1206,11 @@ papers:
     title: Zur Abwehr
     year: '1921'
   qc6CJjYAAAAJ:I9gX6wnfuA8C:
-    citations: 332
+    citations: 334
     title: "\xC4ther und Relativit\xE4tstheorie: Rede gehalten am 5. Mai 1920 an der Reichs-Universit\xE4t zu Leiden"
     year: '1920'
   qc6CJjYAAAAJ:IEpB_1CIIT4C:
-    citations: 3931
+    citations: 3954
     title: 'THE EVOLUTION OF PHYSICS: THE GROWTH OF IDEAS FROM THE EARLY CON CEPTS TO RELATIVITY AND QUANTA.'
     year: '1938'
   qc6CJjYAAAAJ:IHkkN1K1AlAC:
@@ -1226,7 +1226,7 @@ papers:
     title: Sehallausbreitung in teilweise disseziierten Gasen.
     year: '1920'
   qc6CJjYAAAAJ:IWHjjKOFINEC:
-    citations: 801
+    citations: 805
     title: Cosmological considerations on the general theory of relativity
     year: '1986'
   qc6CJjYAAAAJ:IZKZNMMMWs0C:
@@ -1246,7 +1246,7 @@ papers:
     title: 'The collected papers of Albert Einstein. Vol 4, The Swiss years: writings, 1912-1914 [English translation]'
     year: Unknown Year
   qc6CJjYAAAAJ:IjCSPb-OGe4C:
-    citations: 1401
+    citations: 1409
     title: The gravitational equations and the problem of motion
     year: '1938'
   qc6CJjYAAAAJ:IkxDsZK-5NQC:
@@ -1258,7 +1258,7 @@ papers:
     title: 'Zu Max Plancks sechzegstem Geburtstag: Ansprachen, gehalten am 26. April 1918 in der Deutschen Physikalischen Gesellschaft'
     year: '1918'
   qc6CJjYAAAAJ:IqrShC7OVU0C:
-    citations: 6489
+    citations: 6515
     title: Investigations on the theory of the Brownian movement, edited with notes by R
     year: '1926'
   qc6CJjYAAAAJ:IvSMUa3B7yYC:
@@ -1266,7 +1266,7 @@ papers:
     title: "Berichtigung zur Abhandlung:\u201E\xDCber die elektromagnetischen Grundgleichungen f\xFCr bewegte K\xF6rper\u201D \uFE01"
     year: '1908'
   qc6CJjYAAAAJ:J-pR_7NvFogC:
-    citations: 847
+    citations: 848
     title: 'The Swiss Years: Writings, 1914-1917'
     year: '1996'
   qc6CJjYAAAAJ:J4wmHkHhN-kC:
@@ -1278,19 +1278,19 @@ papers:
     title: Tables of Einstein Functions
     year: '1962'
   qc6CJjYAAAAJ:JQPmwQThujIC:
-    citations: 469
+    citations: 473
     title: "La g\xE9om\xE9trie et l'exp\xE9rience, par Albert Einstein; traduit par Maurice Solovine"
     year: '1921'
   qc6CJjYAAAAJ:JXi_AgyUMBAC:
-    citations: 100
+    citations: 101
     title: Relativistic theory of the non-symmetric field
     year: '1955'
   qc6CJjYAAAAJ:JZsVLox4iN8C:
-    citations: 2456
+    citations: 2471
     title: 'Autobiographisches in: Albert Einstein: Philosopher-Scientist'
     year: '1949'
   qc6CJjYAAAAJ:J_g5lzvAfSwC:
-    citations: 138
+    citations: 140
     title: Warum Krieg?
     year: '1972'
   qc6CJjYAAAAJ:JjPkQosUWiAC:
@@ -1314,7 +1314,7 @@ papers:
     title: Fundamental ideas and problems of the theory of relativity
     year: '2009'
   qc6CJjYAAAAJ:K4-iKlO5MD4C:
-    citations: 755
+    citations: 764
     title: A Heuristic Viewpoint Concerning the Production and Transformation of Light
     year: '1929'
   qc6CJjYAAAAJ:K6kyChav4UkC:
@@ -1342,7 +1342,7 @@ papers:
     title: Why socialism?
     year: '1951'
   qc6CJjYAAAAJ:KOc9rAu6-V4C:
-    citations: 404
+    citations: 409
     title: letter to Max Born
     year: '1926'
   qc6CJjYAAAAJ:KQ7zX_ltr48C:
@@ -1370,7 +1370,7 @@ papers:
     title: "Die spezielle Relativit\xE4sthorie"
     year: '1912'
   qc6CJjYAAAAJ:KlAtU1dfN6UC:
-    citations: 454
+    citations: 460
     title: On the Influence of Gravitation on the Propagation of Light
     year: '1911'
   qc6CJjYAAAAJ:KqnX2w3egDsC:
@@ -1390,7 +1390,7 @@ papers:
     title: 'Albert Einstein] to Mileva Einstein-Maric: Letter, after 17 Mar 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:L7JqRCIhofwC:
-    citations: 6810
+    citations: 6877
     title: Sitzungsberichte der Preussischen Akademie der Wissenschaften zu Berlin
     year: '1915'
   qc6CJjYAAAAJ:L7vk9XBBNxgC:
@@ -1406,7 +1406,7 @@ papers:
     title: Briefwechsel 1916-1955
     year: '1972'
   qc6CJjYAAAAJ:LGA7_l5-FVwC:
-    citations: 131
+    citations: 132
     title: Preussiche Akademie der Wissenchaften Berlin
     year: '1927'
   qc6CJjYAAAAJ:LIyjJRbbAUMC:
@@ -1454,11 +1454,11 @@ papers:
     title: 'Albert Einstein] to Hedwig Born: Letter, 8 Feb 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:LkGwnXOMwfcC:
-    citations: 3156
+    citations: 3236
     title: The foundation of the general theory of relativity
     year: '1916'
   qc6CJjYAAAAJ:LkrQC8aPkXYC:
-    citations: 5401
+    citations: 5461
     title: 'Relativity: The Special and the General Theory: a Popular Exposition by Albert Einstein; Transl. by Robert W. Lawson'
     year: '1961'
   qc6CJjYAAAAJ:Lmuc1furtc4C:
@@ -1506,15 +1506,15 @@ papers:
     title: Two-body problem in general relativity theory
     year: '1936'
   qc6CJjYAAAAJ:M3ejUd6NZC8C:
-    citations: 490
+    citations: 491
     title: "Prinzipielles zur allgemeinen Relativit\xE4tstheorie"
     year: '1918'
   qc6CJjYAAAAJ:M8meJADSprsC:
-    citations: 188
+    citations: 189
     title: El significado de la relatividad
     year: '1971'
   qc6CJjYAAAAJ:MDX3w3dAD3YC:
-    citations: 918
+    citations: 920
     title: Zum quantensatz von Sommerfeld und Epstein
     year: '1917'
   qc6CJjYAAAAJ:MGPUR4WVBMEC:
@@ -1522,7 +1522,7 @@ papers:
     title: "Notiz zu der Arbeit von A. Friedmann \u201E\xDCber die Kr\xFCmmung des Raumes \u201C"
     year: '1923'
   qc6CJjYAAAAJ:ML0RJ9NH7IQC:
-    citations: 330
+    citations: 331
     title: New possibility for a unified field theory of gravitation and electricity
     year: '1928'
   qc6CJjYAAAAJ:MNNNGtAgD4EC:
@@ -1538,7 +1538,7 @@ papers:
     title: "La corr\xE9lation de l'empirique et du rationnel dans l'oeuvre scientifique d'Einstein."
     year: Unknown Year
   qc6CJjYAAAAJ:MXK_kJrjxJIC:
-    citations: 641
+    citations: 649
     title: On a stationary system with spherical symmetry consisting of many gravitating masses
     year: '1939'
   qc6CJjYAAAAJ:MqTxh1vmwXEC:
@@ -1558,7 +1558,7 @@ papers:
     title: Physikalische Grundlagen einer Gravitationstheorie
     year: '1914'
   qc6CJjYAAAAJ:NAGhd4NKCV8C:
-    citations: 147
+    citations: 149
     title: "K\xF6niglich Preu\xDFische Akademie der Wissenschaften Berlin"
     year: '1916'
   qc6CJjYAAAAJ:NGoJ35N4lvkC:
@@ -1566,11 +1566,11 @@ papers:
     title: "Bemerkungen zu P. Harzers Abhandlung \xAB\xDCber die Mitf\xFChrung des Lichtes in Glas und die Aberration\xBB(AN 4748)"
     year: '1914'
   qc6CJjYAAAAJ:NJ774b8OgUMC:
-    citations: 25
+    citations: 26
     title: The advent of the quantum theory
     year: '1951'
   qc6CJjYAAAAJ:NM66qo_NnlUC:
-    citations: 1032
+    citations: 1034
     title: 'The Collected Papers of Albert Einstein: English Translation'
     year: '1989'
   qc6CJjYAAAAJ:NMxIlDl6LWMC:
@@ -1602,11 +1602,11 @@ papers:
     title: Albert Einstein] to Michele Besso:[A first] letter, 21 Jul 1916
     year: Unknown Year
   qc6CJjYAAAAJ:NZNkWSpQBv0C:
-    citations: 86
+    citations: 88
     title: Zum Ehrenfestschen Paradoxon
     year: '1910'
   qc6CJjYAAAAJ:NnTm98qLMbgC:
-    citations: 588
+    citations: 591
     title: Mein weltbild
     year: '1934'
   qc6CJjYAAAAJ:Nnq8S6OXqDYC:
@@ -1618,11 +1618,11 @@ papers:
     title: 'Albert Einstein] to Hermann Weyl: Letter, 15 Apr 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:Ns2bVKt8YxIC:
-    citations: 490
+    citations: 492
     title: Sidelights on Relativity,... I. Ether and Relativity. II. Geometry and Experience
     year: '1922'
   qc6CJjYAAAAJ:Nufq_to8ts0C:
-    citations: 202
+    citations: 206
     title: "Das Prinzip von der Erhaltung der Schwerpunktsbewegung und die Tr\xE4gheit der Energie"
     year: '1906'
   qc6CJjYAAAAJ:Nw5Pwe77XXAC:
@@ -1638,11 +1638,11 @@ papers:
     title: "Die Quantentheorie der spezifischen W\xE4rme"
     year: '1967'
   qc6CJjYAAAAJ:O0MA3yP7Y3UC:
-    citations: 307
+    citations: 309
     title: 'The Collected Papers of Albert Einstein, Volume 8: The Berlin Years: Correspondence, 1914-1918.'
     year: '1998'
   qc6CJjYAAAAJ:O3NaXMp0MMsC:
-    citations: 138
+    citations: 141
     title: How I created the theory of relativity
     year: '1982'
   qc6CJjYAAAAJ:OBae9N4Z9bMC:
@@ -1662,7 +1662,7 @@ papers:
     title: 'Friedrich Wilhelm Foerster und Albert Einstein: Briefwechsel von 1935 bis 1954'
     year: '2001'
   qc6CJjYAAAAJ:OPs5gEIPXMUC:
-    citations: 8237
+    citations: 8367
     title: On gravitational waves Sitzungsber. preuss
     year: '1918'
   qc6CJjYAAAAJ:OTTXONDVkokC:
@@ -1670,7 +1670,7 @@ papers:
     title: On the relativity problem
     year: '2007'
   qc6CJjYAAAAJ:OVe_t5h5bhEC:
-    citations: 274
+    citations: 277
     title: "Mi visi\xF3n del mundo"
     year: '1985'
   qc6CJjYAAAAJ:Oi-j_DTgP3cC:
@@ -1682,7 +1682,7 @@ papers:
     title: The Rise and Fall of the Great Ether
     year: '1993'
   qc6CJjYAAAAJ:OlbiQ0ttILcC:
-    citations: 185
+    citations: 186
     title: "Las teor\xEDas de la relatividad"
     year: '1922'
   qc6CJjYAAAAJ:Ow2R9nchCv8C:
@@ -1694,7 +1694,7 @@ papers:
     title: On German Literature for Viola Da Gamba in the 16th and 17th Centuries
     year: '1977'
   qc6CJjYAAAAJ:P1qO8dLd1z8C:
-    citations: 271
+    citations: 275
     title: The Photoelectric Effect
     year: '1905'
   qc6CJjYAAAAJ:P9oYG7HA76QC:
@@ -1758,7 +1758,7 @@ papers:
     title: "Cien a\xF1os de relatividad: Los art\xEDculos de Albert Einstein de 1905 y 1906"
     year: '2004'
   qc6CJjYAAAAJ:QIV2ME_5wuYC:
-    citations: 757
+    citations: 773
     title: Does the inertia of a body depend upon its energy-content?
     year: '1905'
   qc6CJjYAAAAJ:QKtdBID3u5MC:
@@ -1782,7 +1782,7 @@ papers:
     title: Special and General relativity
     year: '1920'
   qc6CJjYAAAAJ:Q_E8KsG3g9MC:
-    citations: 12
+    citations: 13
     title: Correspondencia (1916-1955)
     year: '1999'
   qc6CJjYAAAAJ:QaLwMs-zPFMC:
@@ -1830,7 +1830,7 @@ papers:
     title: "Physikalische Gesellschaft zu Berlin und Deutsche Gesellschaft f\xFCr technische Physik. Berlin, 17. Juli 1931"
     year: '2006'
   qc6CJjYAAAAJ:R3hNpaxXUhUC:
-    citations: 291
+    citations: 296
     title: "Lettres \xE0 Maurice Solovine"
     year: '1956'
   qc6CJjYAAAAJ:R6aXIXmdpM0C:
@@ -1838,7 +1838,7 @@ papers:
     title: Pourquoi le socialisme?
     year: '1993'
   qc6CJjYAAAAJ:RF4BjkDOTHkC:
-    citations: 978
+    citations: 979
     title: "Letters on Wave Mechanics: Correspondence with HA Lorentz, Max Planck, and Erwin Schr\xF6dinger"
     year: '2011'
   qc6CJjYAAAAJ:RJNGbXJAtMsC:
@@ -1846,7 +1846,7 @@ papers:
     title: 'The essential Einstein: his greatest works'
     year: '2008'
   qc6CJjYAAAAJ:RPps9qLA3-kC:
-    citations: 106
+    citations: 107
     title: Letter to Jacques Hadamard
     year: '1952'
   qc6CJjYAAAAJ:Rc-B-9qnGaUC:
@@ -1854,11 +1854,11 @@ papers:
     title: Bemerkungen iiber den Wandel der Problemstcllungen in der theoretischen Physik
     year: Unknown Year
   qc6CJjYAAAAJ:RfUwGJFMQ-0C:
-    citations: 4527
+    citations: 4550
     title: Zur quantentheorie der strahlung
     year: '1917'
   qc6CJjYAAAAJ:RgMnzfD6kpIC:
-    citations: 15
+    citations: 16
     title: Only then shall we find courage
     year: '1946'
   qc6CJjYAAAAJ:RmQ8dt0hH3oC:
@@ -1878,7 +1878,7 @@ papers:
     title: "Kinetische Theorie des W\xE4rmegleichgewichtes und des zweiten Hauptsatzes der Thermodynamik"
     year: '1902'
   qc6CJjYAAAAJ:S9V7H-Nz35UC:
-    citations: 7713
+    citations: 7789
     title: On a Heuristic Point of View Toward the Emission and Transformation of Light
     year: '1905'
   qc6CJjYAAAAJ:SFOYbPikdlgC:
@@ -1894,7 +1894,7 @@ papers:
     title: 'Albert Einstein] to Max Born: Letter, after 29 Jun 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:S_Qw7xXuMuIC:
-    citations: 83
+    citations: 84
     title: 'The collected papers of Albert Einstein: The Berlin years: correspondence, January-December 1921'
     year: '2009'
   qc6CJjYAAAAJ:S_fw-_riRmcC:
@@ -1902,7 +1902,7 @@ papers:
     title: Albert einstein to max born
     year: '2005'
   qc6CJjYAAAAJ:Se3iqnhoufwC:
-    citations: 986
+    citations: 989
     title: The world as I see it
     year: '2007'
   qc6CJjYAAAAJ:SenaEjHFqFYC:
@@ -1914,7 +1914,7 @@ papers:
     title: ALBERT EINSTEIN, UN HOMBRE UNIVERSAL
     year: Unknown Year
   qc6CJjYAAAAJ:ShjGdcaqzI0C:
-    citations: 185
+    citations: 186
     title: "\xDCber die elektromagnetischen Grundgleichungen f\xFCr bewegte K\xF6rper"
     year: '1908'
   qc6CJjYAAAAJ:Sipo1f_CKiIC:
@@ -1926,7 +1926,7 @@ papers:
     title: 'Albert Einstein] to Wander and Geertruida de Haas: Letter, 3 Oct 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:SrKkpNFED5gC:
-    citations: 594
+    citations: 596
     title: "Zum gegenw\xE4rtigen Stand des Strahlungsproblems"
     year: '1909'
   qc6CJjYAAAAJ:SrsqWtBqNIQC:
@@ -1938,7 +1938,7 @@ papers:
     title: 'Albert Einstein] to Wladyslaw Natanson: Letter, 24 Aug 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:SzsLJvG5eXAC:
-    citations: 2026
+    citations: 2041
     title: Autobiographical Notes, ed
     year: '1979'
   qc6CJjYAAAAJ:T64LSalLz9oC:
@@ -1946,7 +1946,7 @@ papers:
     title: 'Albert Einstein] to Willem de Sitter: Letter, 23 Jan 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:T8_be82Iz5gC:
-    citations: 153
+    citations: 154
     title: Zur Theorie des statischen Gravitationsfeldes
     year: '2006'
   qc6CJjYAAAAJ:TA1nTKmGtTgC:
@@ -1962,7 +1962,7 @@ papers:
     title: The new field theory
     year: '1929'
   qc6CJjYAAAAJ:TIZ-Mc8IlK0C:
-    citations: 1106
+    citations: 1112
     title: On the method of theoretical physics
     year: '1934'
   qc6CJjYAAAAJ:TKTY8N1AUUAC:
@@ -1990,7 +1990,7 @@ papers:
     title: "Hamilton\u2019s principle and the general theory of relativity"
     year: '1916'
   qc6CJjYAAAAJ:TiIbgCYny7sC:
-    citations: 9360
+    citations: 9470
     title: "Zur Elektrodynamik bewegter K\xF6rper"
     year: Unknown Year
   qc6CJjYAAAAJ:TmnWbB_axlEC:
@@ -2018,7 +2018,7 @@ papers:
     title: 'Albert Einstein] to Otto Naumann: Letter, 7 Dec 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:ULOm3_A8WrAC:
-    citations: 320
+    citations: 321
     title: On the motion of particles in general relativity theory
     year: '1949'
   qc6CJjYAAAAJ:UO8fSLLLPykC:
@@ -2046,11 +2046,11 @@ papers:
     title: The Effect of Autonomous Algorithms on Networking
     year: Unknown Year
   qc6CJjYAAAAJ:UeHWp8X0CEIC:
-    citations: 60
+    citations: 59
     title: "Sobre la electrodin\xE1mica de los cuerpos en movimiento"
     year: '2005'
   qc6CJjYAAAAJ:UebtZRa9Y70C:
-    citations: 1022
+    citations: 1028
     title: "\xDCber die spezielle und die allgemeine Relativit\xE4tstheorie"
     year: '2008'
   qc6CJjYAAAAJ:UlRcoTO8nVoC:
@@ -2058,7 +2058,7 @@ papers:
     title: On a Jewish Palestine. First Version, before 27 Jun 1921
     year: Unknown Year
   qc6CJjYAAAAJ:Ul_CLA4dPeMC:
-    citations: 210
+    citations: 212
     title: 'Religion and Science: Irreconcilable?'
     year: '1948'
   qc6CJjYAAAAJ:UnhBtiQKoKQC:
@@ -2126,7 +2126,7 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 3 Mar 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:VglVhKISWcQC:
-    citations: 8
+    citations: 9
     title: ON A HEURISTIC VIEWPOINT OF THE CREATION AND MODIFICATION OF LIGHT
     year: '1905'
   qc6CJjYAAAAJ:VjBpw8Hezy4C:
@@ -2146,7 +2146,7 @@ papers:
     title: 'The collected papers of Albert Einstein. Vol 6, The Berlin years: writings, 1914-1917:[English translation]'
     year: '2002'
   qc6CJjYAAAAJ:VyOdxF-JhwgC:
-    citations: 256
+    citations: 257
     title: SB preuss
     year: '1916'
   qc6CJjYAAAAJ:VyewGSb6xwwC:
@@ -2162,7 +2162,7 @@ papers:
     title: "L'\xE9tat actuel du probl\xE8me des chaleurs sp\xE9cifiques"
     year: '1912'
   qc6CJjYAAAAJ:W7OEmFMy1HYC:
-    citations: 1618
+    citations: 1640
     title: Lens-like action of a star by the deviation of light in the gravitational field
     year: '1936'
   qc6CJjYAAAAJ:WC4w5-ZrDNIC:
@@ -2174,7 +2174,7 @@ papers:
     title: La discussion Einstein-Bohr.
     year: Unknown Year
   qc6CJjYAAAAJ:WF5omc3nYNoC:
-    citations: 1059
+    citations: 1062
     title: On gravitational waves
     year: '1937'
   qc6CJjYAAAAJ:WIVIxizkzXoC:
@@ -2186,11 +2186,11 @@ papers:
     title: "Relativit\xE4t und gravitation. Erwiderung auf eine bemerkung von M. Abraham"
     year: '1912'
   qc6CJjYAAAAJ:WM2K3OHRCGMC:
-    citations: 219
+    citations: 217
     title: "Notas autobiogr\xE1ficas"
     year: '2003'
   qc6CJjYAAAAJ:WMtz-WDmgKQC:
-    citations: 56
+    citations: 57
     title: "Newtons Mechanik und ihr Einflu\xDF auf die Gestaltung der theoretischen Physik"
     year: '1927'
   qc6CJjYAAAAJ:WQTnNU6cpycC:
@@ -2274,7 +2274,7 @@ papers:
     title: 'Albert Einstein] to Paul Gruner: Letter, 11 Feb 1908'
     year: Unknown Year
   qc6CJjYAAAAJ:XZvG1uL-wj0C:
-    citations: 1154
+    citations: 1160
     title: 'On the method of theoretical physics: The Herbert Spencer lecture, delivered at Oxford 10 June 1933'
     year: '1933'
   qc6CJjYAAAAJ:Xc-mKOjpdrwC:
@@ -2286,7 +2286,7 @@ papers:
     title: 'The Collected Papers of Albert Einstein, Volume 9: The Berlin Years: Correspondence, January 1919-April 1920'
     year: '2004'
   qc6CJjYAAAAJ:XdwVV_xN3QMC:
-    citations: 1518
+    citations: 1536
     title: Draft of a Generalized Theory of Relativity and a Theory of Gravitation
     year: '1913'
   qc6CJjYAAAAJ:XeErXHja3Z8C:
@@ -2322,7 +2322,7 @@ papers:
     title: "Research@ FrankfurtSchool in Zeiten der Finanzmarktkrise \u201EA Collection of Working Papers \u201C"
     year: Unknown Year
   qc6CJjYAAAAJ:Y0agIcFmOsQC:
-    citations: 1204
+    citations: 1207
     title: A correction on my work-A new determination of molecular dimensions
     year: '1969'
   qc6CJjYAAAAJ:Y1W0x10ZrwMC:
@@ -2382,7 +2382,7 @@ papers:
     title: Physics, philosophy and scientific progress.
     year: '1950'
   qc6CJjYAAAAJ:YoqGh_aPxy4C:
-    citations: 79
+    citations: 80
     title: The common language of science
     year: '1941'
   qc6CJjYAAAAJ:YpRCXavlr0AC:
@@ -2390,7 +2390,7 @@ papers:
     title: 'Albert Einstein] to Michele and Anna Besso-Winteler: Letter, 1 Aug 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:YsMSGLbcyi4C:
-    citations: 2364
+    citations: 2404
     title: The particle problem in the general theory of relativity
     year: '1935'
   qc6CJjYAAAAJ:YvgfBAebZEkC:
@@ -2398,11 +2398,11 @@ papers:
     title: 'Notice to the world: renounce war or perish; world peace or universal death.[Sound recording]'
     year: '1955'
   qc6CJjYAAAAJ:Z5m8FVwuT1cC:
-    citations: 19
+    citations: 20
     title: Mi credo humanista
     year: '1991'
   qc6CJjYAAAAJ:ZDu_srLEjN8C:
-    citations: 144
+    citations: 146
     title: Preussische akademie der wissenschaften, Phys-math
     year: '1925'
   qc6CJjYAAAAJ:ZEcFV8kAgqMC:
@@ -2430,7 +2430,7 @@ papers:
     title: 'Briefwechsel: Sechzig Briefe aus dem goldenen Zeitalter der modernen Physik'
     year: '1968'
   qc6CJjYAAAAJ:ZbQVaL1IMbQC:
-    citations: 4077
+    citations: 4097
     title: Quanzeml~ orie der stralllung
     year: '1916'
   qc6CJjYAAAAJ:ZbiiB1Sm8G8C:
@@ -2438,11 +2438,11 @@ papers:
     title: 'Albert Einstein] to Michele Besso: Letter, 6 Apr 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:ZeXyd9-uunAC:
-    citations: 349
+    citations: 352
     title: "Physik und realit\xE4t"
     year: '1936'
   qc6CJjYAAAAJ:ZfRJV9d4-WMC:
-    citations: 98
+    citations: 99
     title: Pourquoi la guerre?
     year: '1933'
   qc6CJjYAAAAJ:ZgPQhQxLujAC:
@@ -2458,7 +2458,7 @@ papers:
     title: 'Relativiteit: speciale en algemene theorie'
     year: '1986'
   qc6CJjYAAAAJ:Zph67rFs4hoC:
-    citations: 398
+    citations: 399
     title: "Grundz\xFCge der Relativit\xE4tstheorie"
     year: '2002'
   qc6CJjYAAAAJ:ZppSRAJs3i8C:
@@ -2514,11 +2514,11 @@ papers:
     title: "Depuis le principe d'\xE9quivalence jusqu'aux \xE9quations de la gravitation."
     year: Unknown Year
   qc6CJjYAAAAJ:_kc_bZDykSQC:
-    citations: 409
+    citations: 411
     title: A generalization of the relativistic theory of gravitation
     year: '1945'
   qc6CJjYAAAAJ:_mQi-xiA4oYC:
-    citations: 460
+    citations: 462
     title: "Die Relativit\xE4ts-Theorie"
     year: '1911'
   qc6CJjYAAAAJ:a2necdfpwlEC:
@@ -2526,7 +2526,7 @@ papers:
     title: "Eine Beziehung zwischen dem elastischen Verhalten und der spezifischen W\xE4rme bei festen K\xF6rpern mit einatomigem Molek\xFCl"
     year: '1911'
   qc6CJjYAAAAJ:a9-T7VOCCH8C:
-    citations: 3791
+    citations: 3805
     title: The Science and the Life of Albert Einstein
     year: '1982'
   qc6CJjYAAAAJ:aDdGf5um_jkC:
@@ -2534,7 +2534,7 @@ papers:
     title: 'Albert Einstein] to Gustav Mie: Letter, 2 Jun 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:aEPHIGigqugC:
-    citations: 4328
+    citations: 4356
     title: "Physics and Reality, in \u201CIdeas and Opinions\u201D"
     year: '1954'
   qc6CJjYAAAAJ:aEyKTaVlRPYC:
@@ -2570,11 +2570,11 @@ papers:
     title: Zur theorie der lichterzeugung und lichtabsorption
     year: '1906'
   qc6CJjYAAAAJ:adHtZc2wMuEC:
-    citations: 126
+    citations: 128
     title: "Neue M\xF6glichkeit f\xFCr eine einheitliche Feldtheorie von Gravitation und Elektrizit\xE4t"
     year: '1928'
   qc6CJjYAAAAJ:adgdM4TzidAC:
-    citations: 43
+    citations: 44
     title: "Sur l'\xE9lectrodynamique des corps en mouvement"
     year: '1905'
   qc6CJjYAAAAJ:ae0xyBWlIcIC:
@@ -2602,11 +2602,11 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 26 Nov 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:bCjgOgSFrM0C:
-    citations: 1273
+    citations: 1286
     title: "Die plancksche theorie der strahlung und die theorie der spezifischen w\xE4rme"
     year: '1906'
   qc6CJjYAAAAJ:bEWYMUwI8FkC:
-    citations: 283
+    citations: 286
     title: Why war?
     year: '1933'
   qc6CJjYAAAAJ:bFuYayV9R1gC:
@@ -2626,7 +2626,7 @@ papers:
     title: 'Albert Einstein] to Paul Hertz: Letter, 22 Aug 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:bUu3lypoyhcC:
-    citations: 824
+    citations: 828
     title: On the quantum theory of radiation
     year: '1972'
   qc6CJjYAAAAJ:bcT4vkklUMwC:
@@ -2654,7 +2654,7 @@ papers:
     title: "Zur Theorie der Radiometerkr\xE4fte"
     year: '1924'
   qc6CJjYAAAAJ:bnK-pcrLprsC:
-    citations: 31
+    citations: 32
     title: Unified field theory based on Riemannian metrics and distant parallelism
     year: '1930'
   qc6CJjYAAAAJ:boGf3zyra0UC:
@@ -2662,7 +2662,7 @@ papers:
     title: 'The collected papers of Albert Einstein. vol. 9, The Berlin years: correspondence, January 1919-April 1920:[English translation]'
     year: Unknown Year
   qc6CJjYAAAAJ:brChLMnLtjYC:
-    citations: 184
+    citations: 185
     title: Relativity Principle and its Consequences in Modern Physics. Collection of Scientific Works, V. 1
     year: '1965'
   qc6CJjYAAAAJ:bsl25C5uMOsC:
@@ -2686,7 +2686,7 @@ papers:
     title: The Fight Against War
     year: '1933'
   qc6CJjYAAAAJ:c4A-nLdbYHEC:
-    citations: 1550
+    citations: 1560
     title: 'Concepts of space: The history of theories of space in physics'
     year: '1969'
   qc6CJjYAAAAJ:c5LcigzBm8MC:
@@ -2702,7 +2702,7 @@ papers:
     title: 'In Memory of Emmy Noether...: Abstract of Address Delivered by Professor Hermann Weyl... and Copy of Letter of Professor Albert Einstein'
     year: '1935'
   qc6CJjYAAAAJ:cNe27ouKFcQC:
-    citations: 7700
+    citations: 7839
     title: "Die grundlage der allgemeinen relativit\xE4tstheorie"
     year: '2006'
   qc6CJjYAAAAJ:cOfwuRB03ygC:
@@ -2710,11 +2710,11 @@ papers:
     title: "Die spezielle relativit\xE4tstheorie Einsteins und die logik"
     year: '1924'
   qc6CJjYAAAAJ:cRMvf6lLvU8C:
-    citations: 293
+    citations: 292
     title: "Einige Argumente f\xFCr die Annahme einer molekularen Agitation beim absoluten Nullpunkt"
     year: '1913'
   qc6CJjYAAAAJ:cSdaV2aYdYsC:
-    citations: 375
+    citations: 376
     title: Spielen Gravitationsfelder im Aufbau der materiellen Elementarteilchen eine wesentliche Rolle?
     year: '1919'
   qc6CJjYAAAAJ:cTdzRpWJKHEC:
@@ -2758,7 +2758,7 @@ papers:
     title: "Signification de la relativit\xE9: appendice \xE0 la cinqui\xE8me \xE9dition de\" The meaning of relativity\"(d\xE9cembre 1954). Compl\xE9ments"
     year: '1960'
   qc6CJjYAAAAJ:d4tt_xEv1X8C:
-    citations: 220
+    citations: 221
     title: Lichtgeschwindigkeit und statik des Gravitationsfeldes
     year: '1912'
   qc6CJjYAAAAJ:d6JCS5z0ckYC:
@@ -2766,7 +2766,7 @@ papers:
     title: The establishment of an international bureau of meteorology
     year: '1927'
   qc6CJjYAAAAJ:dBIO0h50nwkC:
-    citations: 47
+    citations: 49
     title: Physics & reality
     year: '2003'
   qc6CJjYAAAAJ:dDz6LBb16w8C:
@@ -2802,7 +2802,7 @@ papers:
     title: 'Albert Einstein] to Max Born: Letter, after 3 Jul 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:dhFuZR0502QC:
-    citations: 201
+    citations: 202
     title: 'Corrections and additional remarks to our paper: The influence of the expansion of space on the gravitation fields surrounding the individual stars'
     year: '1946'
   qc6CJjYAAAAJ:dhZ1Wuf5EGsC:
@@ -2826,7 +2826,7 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 4 Nov 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:e84hm74t-eoC:
-    citations: 5799
+    citations: 5812
     title: "Eine neue bestimmung der molek\xFCldimensionen"
     year: '1906'
   qc6CJjYAAAAJ:eAUscmXIlQ8C:
@@ -2842,7 +2842,7 @@ papers:
     title: Besprechungen
     year: '1918'
   qc6CJjYAAAAJ:eJXPG6dFmWUC:
-    citations: 492
+    citations: 497
     title: The theory of relativity
     year: '1996'
   qc6CJjYAAAAJ:eKGuBlYFiu8C:
@@ -2918,7 +2918,7 @@ papers:
     title: 'Albert Einstein] to Kathia Adler: Letter, 20 Feb 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:fLJJVVwU7EQC:
-    citations: 355
+    citations: 358
     title: "Ein einfaches Experiment zum Nachweis der Amp\xE8reschen Molekularstr\xF6me"
     year: '1916'
   qc6CJjYAAAAJ:fPk4N6BV_jEC:
@@ -2966,7 +2966,7 @@ papers:
     title: On the limit of validity of the law of thermodynamic equilibrium and on the possibility of a new determination of the elementary quanta
     year: '1907'
   qc6CJjYAAAAJ:g5m5HwL7SMYC:
-    citations: 146
+    citations: 147
     title: TIME, SPACE, AND GRAVITATION.
     year: '1920'
   qc6CJjYAAAAJ:gKLIUvgTho8C:
@@ -2982,7 +2982,7 @@ papers:
     title: Zu Dr. Berliners siebzigstem Geburtstag
     year: '1932'
   qc6CJjYAAAAJ:gV6rEsy15s0C:
-    citations: 3818
+    citations: 3914
     title: Bemerkungen zu der Arbeit
     year: '1914'
   qc6CJjYAAAAJ:gYAb_yFic6IC:
@@ -2990,7 +2990,7 @@ papers:
     title: Zur Methodik der Theoretischen Physik
     year: '1934'
   qc6CJjYAAAAJ:gmHTDCtJMcoC:
-    citations: 159
+    citations: 161
     title: "Folgerungen aus den Capillarit\xE4tserscheinungen"
     year: '1901'
   qc6CJjYAAAAJ:gqMmJtG4vxUC:
@@ -3014,7 +3014,7 @@ papers:
     title: Reply to critics
     year: '1949'
   qc6CJjYAAAAJ:hEp1lTclR2YC:
-    citations: 325
+    citations: 328
     title: On the generalized theory of gravitation
     year: '1950'
   qc6CJjYAAAAJ:hKjooKYXoHIC:
@@ -3022,7 +3022,7 @@ papers:
     title: "\xDCber die formale Beziehung des Riemannschen Kr\xFCmmungstensors zu den Feldgleichungen der Gravitation"
     year: '1927'
   qc6CJjYAAAAJ:hMod-77fHWUC:
-    citations: 5211
+    citations: 5268
     title: "La relativit\xE9"
     year: '1964'
   qc6CJjYAAAAJ:hMwNgRnlwaMC:
@@ -3030,7 +3030,7 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 10 Sep 1914'
     year: Unknown Year
   qc6CJjYAAAAJ:hTqO-V9ugBQC:
-    citations: 43
+    citations: 44
     title: "Sur l'\xE9lectrodynamique des corps en mouvement"
     year: '1965'
   qc6CJjYAAAAJ:hUq98zRk74IC:
@@ -3038,15 +3038,15 @@ papers:
     title: EddingtonsTheorie und Hamiltonsches Prinzip
     year: '1925'
   qc6CJjYAAAAJ:hVd5agGqjXwC:
-    citations: 3801
+    citations: 3822
     title: Physikalische Gesellschaft Zuerich
     year: '1916'
   qc6CJjYAAAAJ:hbz17DqrwuEC:
-    citations: 348
+    citations: 351
     title: Notiz zu unserer Arbeit
     year: '1915'
   qc6CJjYAAAAJ:hcF2OqvMasEC:
-    citations: 138
+    citations: 140
     title: Warum Krieg?
     year: '1933'
   qc6CJjYAAAAJ:he8YCnfqqkoC:
@@ -3082,7 +3082,7 @@ papers:
     title: 'As it was: the UNESCO Courier December 1951'
     year: '1996'
   qc6CJjYAAAAJ:iH-uZ7U-co4C:
-    citations: 115
+    citations: 116
     title: Knowledge of past and future in quantum mechanics
     year: '1931'
   qc6CJjYAAAAJ:iKmOvsfbmGkC:
@@ -3102,7 +3102,7 @@ papers:
     title: Geometria no euclidea y fisica
     year: '1926'
   qc6CJjYAAAAJ:i_7YvbSbtFEC:
-    citations: 8759
+    citations: 8906
     title: "Berichtigung zu meiner Arbeit:\u201EEine neue Bestimmung der Molek\xFCldimensionen\u201D \uFE01"
     year: '2006'
   qc6CJjYAAAAJ:ifIdVpG6JtcC:
@@ -3114,7 +3114,7 @@ papers:
     title: Relativites restreinte et generale Relativite generale, cosmologie et theories unitaires
     year: '1994'
   qc6CJjYAAAAJ:inmFHauC9wsC:
-    citations: 245
+    citations: 246
     title: Statistische Untersuchung der Bewegung eines Resonators in einem Strahlungsfeld
     year: '1910'
   qc6CJjYAAAAJ:iomT83CKXisC:
@@ -3122,7 +3122,7 @@ papers:
     title: "La th\xE9orie de la relativit\xE9 d'Einstein et la dialectique."
     year: Unknown Year
   qc6CJjYAAAAJ:isC4tDSrTZIC:
-    citations: 4190
+    citations: 4294
     title: "\xDCber Gravitationswellen"
     year: '1918'
   qc6CJjYAAAAJ:it4f3qIuXWYC:
@@ -3138,11 +3138,11 @@ papers:
     title: Principles of research
     year: '1954'
   qc6CJjYAAAAJ:j5aT6aphRxQC:
-    citations: 240
+    citations: 241
     title: "Zum gegenw\xE4rtigen Stande des Gravitations-problems"
     year: '1914'
   qc6CJjYAAAAJ:j8SEvjWlNXcC:
-    citations: 176
+    citations: 177
     title: Letters on absolute parallelism
     year: '1979'
   qc6CJjYAAAAJ:j8pvxH-kN2QC:
@@ -3178,7 +3178,7 @@ papers:
     title: A memorial to PAM Dirac
     year: '1990'
   qc6CJjYAAAAJ:k4O5U3vRA4YC:
-    citations: 5738
+    citations: 5803
     title: The special and general theory
     year: '1920'
   qc6CJjYAAAAJ:k6nH7jlkaTkC:
@@ -3190,7 +3190,7 @@ papers:
     title: Hedwig und Max Born
     year: '1916'
   qc6CJjYAAAAJ:kFzFP8IdBVAC:
-    citations: 378
+    citations: 383
     title: Einstein's essays in science
     year: '2009'
   qc6CJjYAAAAJ:kGbpvR7Ecy8C:
@@ -3202,11 +3202,11 @@ papers:
     title: "Briefwechsel 1916\xB11955 von Albert Einstein und Hedwig und Max Born, Kommentiert von Max Born"
     year: '1969'
   qc6CJjYAAAAJ:kNdYIx-mwKoC:
-    citations: 480
+    citations: 482
     title: Sidelights on relativity
     year: '2009'
   qc6CJjYAAAAJ:kO05sadLmrgC:
-    citations: 67
+    citations: 68
     title: "Bemerkungen zu der Notiz von Hrn. Paul Ehrenfest:\u201D \uFE01Die Translation deformierbarer Elektronen und der Fl\xE4chensatz \u201E"
     year: '1907'
   qc6CJjYAAAAJ:kPzzr9KoCG0C:
@@ -3222,7 +3222,7 @@ papers:
     title: "Albert Einstein] to Walter D\xE4llenbach: Letter, after 15 Feb 1917"
     year: Unknown Year
   qc6CJjYAAAAJ:kqeZabM7ilsC:
-    citations: 6923
+    citations: 7031
     title: Preuss, Sitzungsber
     year: '1915'
   qc6CJjYAAAAJ:l0_JBNIuc60C:
@@ -3234,11 +3234,11 @@ papers:
     title: Court Expert Opinion in the Matter of Signal Co. vs. Atlas Works, ca. 3 Dec 1921
     year: Unknown Year
   qc6CJjYAAAAJ:l6Q3WhenKVUC:
-    citations: 592
+    citations: 593
     title: Geometrie und erfahrung
     year: '1921'
   qc6CJjYAAAAJ:l7t_Zn2s7bgC:
-    citations: 656
+    citations: 660
     title: Ether and the Theory of Relativity
     year: '2007'
   qc6CJjYAAAAJ:lAj_JhtUatoC:
@@ -3254,7 +3254,7 @@ papers:
     title: The collecteds of albert einstein v 9 the berlin years correspondence january 1919-april 1920 english translation (paperback)
     year: '2004'
   qc6CJjYAAAAJ:lEqHes_HPG0C:
-    citations: 791
+    citations: 798
     title: 'The principle of relativity: a collection of original memoirs on the special and general theory of relativity'
     year: '1923'
   qc6CJjYAAAAJ:lIaPce-xyHYC:
@@ -3266,11 +3266,11 @@ papers:
     title: "Grundgedanken und Probleme der Relativit\xE4tstheorie"
     year: '1923'
   qc6CJjYAAAAJ:lLPirIASiZEC:
-    citations: 855
+    citations: 857
     title: "The Collected Papers of Albert Einstein, Volume 15 (Translation Supplement): The Berlin Years: Writings & Correspondence, June 1925\u2013May 1927"
     year: '2018'
   qc6CJjYAAAAJ:lOG7zRu2uA8C:
-    citations: 65
+    citations: 66
     title: The foundations of general relativity theory
     year: '1973'
   qc6CJjYAAAAJ:lPNvfOEJVFUC:
@@ -3306,7 +3306,7 @@ papers:
     title: A new form of the general relativistic field equations
     year: '1955'
   qc6CJjYAAAAJ:mN77zE6YZBUC:
-    citations: 727
+    citations: 732
     title: Ueber spezielle und allgemeine Relativitaetstheorie, 127
     year: '1969'
   qc6CJjYAAAAJ:mNm_27jwclsC:
@@ -3330,7 +3330,7 @@ papers:
     title: 'Albert Einstein] to Max Born: Letter, 27 Feb 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:maZDTaKrznsC:
-    citations: 116
+    citations: 118
     title: The Bianchi identities in the generalized theory of gravitation
     year: '1950'
   qc6CJjYAAAAJ:mdGv78FIKkEC:
@@ -3342,7 +3342,7 @@ papers:
     title: Albert Einstein] to Michele Besso:[A second] letter, 21 Jul 1916
     year: Unknown Year
   qc6CJjYAAAAJ:mnAcAzq93VMC:
-    citations: 120
+    citations: 124
     title: Riemannian Geometry with Maintaining the Notion of distant parallelism
     year: '1928'
   qc6CJjYAAAAJ:mpaOjDK6XBIC:
@@ -3386,11 +3386,11 @@ papers:
     title: Einstein und die Interviewer, 10 Aug 1921
     year: Unknown Year
   qc6CJjYAAAAJ:nazVBdFzvK0C:
-    citations: 161
+    citations: 162
     title: Einstein on Peace, ed. Otto Nathan and Heinz Norden
     year: '1960'
   qc6CJjYAAAAJ:njp6nI0QjqAC:
-    citations: 456
+    citations: 457
     title: "\xDCber die Entwickelung unserer Anschauungen \xFCber das Wesen und die Konstitution der Strahlung"
     year: '1909'
   qc6CJjYAAAAJ:nlKf13ul9_IC:
@@ -3418,11 +3418,11 @@ papers:
     title: "Neue Zugangswege zur Entw\xF6hnungs-behandlung in Sachsen, Sachsen-Anhalt und Th\xFCringen"
     year: Unknown Year
   qc6CJjYAAAAJ:nwfoItMF7hMC:
-    citations: 441
+    citations: 443
     title: "Teor\u0131a cu\xE1ntica de gases ideales monoat\xF3micos, Sitz"
     year: '1924'
   qc6CJjYAAAAJ:o4Qvs5Y5TLQC:
-    citations: 993
+    citations: 996
     title: The Early Years 1879-1902
     year: '1987'
   qc6CJjYAAAAJ:o9ULDYDKYbIC:
@@ -3434,7 +3434,7 @@ papers:
     title: Eine neue formale Deutung der Maxwellschen Feldgleichungen der Elektrodynamik
     year: '1916'
   qc6CJjYAAAAJ:oFKsPyNwwpYC:
-    citations: 85
+    citations: 86
     title: "\xDCber die M\xF6glichkeit einer neuen Pr\xFCfung des Relativit\xE4tsprinzips"
     year: '2006'
   qc6CJjYAAAAJ:oFWWKr2Zb18C:
@@ -3454,7 +3454,7 @@ papers:
     title: 'Le pouvoir nu: propos sur la guerre et la paix, 1914-1955'
     year: '1991'
   qc6CJjYAAAAJ:oYLFIHfuHKwC:
-    citations: 247
+    citations: 248
     title: "Zum kosmologischen Problem der allgemeinen Relativit\xE4tstheorie"
     year: '1931'
   qc6CJjYAAAAJ:oea97a5D_h0C:
@@ -3462,7 +3462,7 @@ papers:
     title: "\xDCber den gegenw\xE4rtigen Stand der allgemeinen Relativit\xE4tsteorie"
     year: '1930'
   qc6CJjYAAAAJ:ojlX30-wUrgC:
-    citations: 192
+    citations: 194
     title: Religion and science
     year: '1930'
   qc6CJjYAAAAJ:oldoQiaHq2UC:
@@ -3470,7 +3470,7 @@ papers:
     title: "Einheitliche Theorie von Gravitation und Elektrizit\xE4t. Zweite Abhandlung"
     year: '2006'
   qc6CJjYAAAAJ:oqD4_j7ulsYC:
-    citations: 20513
+    citations: 20616
     title: On the movement of small particles suspended in stationary liquids required by the molecular-kinetic theory of heat
     year: '1905'
   qc6CJjYAAAAJ:osi8XriVlOYC:
@@ -3478,7 +3478,7 @@ papers:
     title: 'Albert Einstein] to Wander and Geertruida de Haas: Letter, 6 Jul 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:oursBaop5wYC:
-    citations: 1516
+    citations: 1512
     title: Zur theorie der brownschen bewegung
     year: '1906'
   qc6CJjYAAAAJ:oy0z8GdgWhYC:
@@ -3554,7 +3554,7 @@ papers:
     title: What is the Responsibility of Scientists in War?
     year: Unknown Year
   qc6CJjYAAAAJ:q1ZQJjUA47MC:
-    citations: 225
+    citations: 226
     title: On the motion, required by the molecular-kinetic theory of heat, of particles suspended in a fluid at rest
     year: '1905'
   qc6CJjYAAAAJ:q2Dn1KgioksC:
@@ -3574,11 +3574,11 @@ papers:
     title: "Quatre conf\xE9rences sur la th\xE9orie de la relativit\xE9 faites \xE0 l'Universit\xE9 de Princeton"
     year: '2005'
   qc6CJjYAAAAJ:qCpRzq7zkD8C:
-    citations: 2197
+    citations: 2217
     title: "Zur allgemeinen Relativit\xE4tstheorie"
     year: '1915'
   qc6CJjYAAAAJ:qPeb-qHga9sC:
-    citations: 307
+    citations: 309
     title: "Auf die Riemann-Metrik und den Fern-Parallelismus gegr\xFCndete einheitliche Feldtheorie"
     year: '1930'
   qc6CJjYAAAAJ:qbqt7gslDFUC:
@@ -3590,11 +3590,11 @@ papers:
     title: "En busca del eslab\xF3n perdido entre educaci\xF3n y desarrollo: desaf\xEDos y retos para la universidad en Am\xE9rica Latina y el Caribe"
     year: Unknown Year
   qc6CJjYAAAAJ:qjMakFHDy7sC:
-    citations: 3319
+    citations: 3363
     title: On the electrodynamics of moving bodies
     year: '1905'
   qc6CJjYAAAAJ:qsWQJNntlusC:
-    citations: 3212
+    citations: 3227
     title: Ideas and opinions
     year: '1995'
   qc6CJjYAAAAJ:quBVm8e4N6QC:
@@ -3602,11 +3602,11 @@ papers:
     title: "Zu Kaluzas Theorie des Zusammenhanges von Gravitation und Elektrizit\xE4t. Zweite Mitteilung"
     year: '2006'
   qc6CJjYAAAAJ:qxL8FJ1GzNcC:
-    citations: 615
+    citations: 616
     title: Geometrie und erfahrung
     year: '1921'
   qc6CJjYAAAAJ:qyhmnyLat1gC:
-    citations: 27746
+    citations: 27962
     title: Can quantum-mechanical description of physical reality be considered complete?
     year: '1935'
   qc6CJjYAAAAJ:qzuIxkxWBNsC:
@@ -3638,7 +3638,7 @@ papers:
     title: Oorlog als ziekte. Met een voorw. van Albert Einstein. Naar de Nederlandse vertaling bewerkt door C. van Emde Boas
     year: '1938'
   qc6CJjYAAAAJ:rCzfLUpcSPoC:
-    citations: 449
+    citations: 451
     title: "A evolu\xE7\xE3o da f\xEDsica: o desenvolvimento das ideias desde os primitivos conceitos at\xE9 \xE0 Relatividade e aos Quanta"
     year: '1939'
   qc6CJjYAAAAJ:rFyVMFCKTwsC:
@@ -3650,7 +3650,7 @@ papers:
     title: "Gelegentliches: Zum f\xFCnfzigsten Geburtstag 14. M\xE4rz 1929 dargebracht von der Soncino-Gesellschaft der Freunde des J\xFCdischen Buches zu Berlin"
     year: '1929'
   qc6CJjYAAAAJ:rPbfW60zdgkC:
-    citations: 1193
+    citations: 1207
     title: Physics and reality
     year: '1936'
   qc6CJjYAAAAJ:rQcm2j6_ZE8C:
@@ -3662,7 +3662,7 @@ papers:
     title: A new analysis of molecule dimensions
     year: '1968'
   qc6CJjYAAAAJ:rWqKpwLRvsIC:
-    citations: 3057
+    citations: 3140
     title: Die feldgleichungen der gravitation
     year: Unknown Year
   qc6CJjYAAAAJ:rbgNTKsR3fAC:
@@ -3722,7 +3722,7 @@ papers:
     title: "La th\xE9orie corpusculaire des rayons X et la structure des cristaux."
     year: Unknown Year
   qc6CJjYAAAAJ:sAujV351FBYC:
-    citations: 4861
+    citations: 4885
     title: The meaning of relativity
     year: '1950'
   qc6CJjYAAAAJ:sIDMtVbdO0QC:
@@ -3730,15 +3730,15 @@ papers:
     title: "\xDCber die gegenw\xE4rtige Krise der theoretischen Physik"
     year: '1922'
   qc6CJjYAAAAJ:sJK75vZXtG0C:
-    citations: 207
+    citations: 208
     title: Mis ideas y opiniones
     year: '2011'
   qc6CJjYAAAAJ:sNmaIFBj_lkC:
-    citations: 8
+    citations: 6
     title: Compton Effect
     year: '1966'
   qc6CJjYAAAAJ:sYWh8IhQ1GMC:
-    citations: 13
+    citations: 14
     title: Letter to Michele Besso's Family
     year: '1989'
   qc6CJjYAAAAJ:scjTk0LcRdsC:
@@ -3754,7 +3754,7 @@ papers:
     title: The laws of science and the laws of ethics
     year: '1950'
   qc6CJjYAAAAJ:sgsej9ZJWHMC:
-    citations: 4359
+    citations: 4460
     title: "N\xE4herungsweise Integration der Feldgleichungen der Gravitation"
     year: '1916'
   qc6CJjYAAAAJ:siTy-4AL0AwC:
@@ -3810,7 +3810,7 @@ papers:
     title: Storia del concetto di spazio
     year: '1966'
   qc6CJjYAAAAJ:tgTmbKTkO1IC:
-    citations: 16
+    citations: 17
     title: "Nachtrag zu meiner Arbeit:\u201EThermodynamische Begr\xFCndung des photochemischen Aquivalentgesetzes\u201D \uFE01"
     year: '1912'
   qc6CJjYAAAAJ:tkaPQYYpVKoC:
@@ -3822,7 +3822,7 @@ papers:
     title: My Credo
     year: '1986'
   qc6CJjYAAAAJ:tntj4plCNvAC:
-    citations: 123
+    citations: 124
     title: Relativity and the Problem of Space
     year: '1954'
   qc6CJjYAAAAJ:tzPJaSocouwC:
@@ -3838,7 +3838,7 @@ papers:
     title: "equations of motion\uFB01 one therefore could not doubt that the laws of nature are"
     year: '1907'
   qc6CJjYAAAAJ:uCYQzKCmtZwC:
-    citations: 1230
+    citations: 1232
     title: Out of my later years
     year: '1950'
   qc6CJjYAAAAJ:uH1VZYVfkoQC:
@@ -3866,7 +3866,7 @@ papers:
     title: "Bemerkung zu meiner Arbeit \u201CZur allgemeinen Relativit\xE4tstheorie\u201D"
     year: '2006'
   qc6CJjYAAAAJ:ufrVoPGSRksC:
-    citations: 644
+    citations: 647
     title: The influence of the expansion of space on the gravitation fields surrounding the individual stars
     year: '1945'
   qc6CJjYAAAAJ:uh8FjILnQOkC:
@@ -3878,7 +3878,7 @@ papers:
     title: "Lehrs\xE4tze \xFCber das Weltall: Mit Beweis in Form eines offenen Briefes an Professor Einstein. In einer von Gerhard R\xFChm bearbeiteten Neuauflage"
     year: '1965'
   qc6CJjYAAAAJ:ult01sCh7k0C:
-    citations: 422
+    citations: 425
     title: Wolfgang Pauli
     year: '2001'
   qc6CJjYAAAAJ:umqufdRvDiIC:
@@ -3930,7 +3930,7 @@ papers:
     title: On the five-dimensional representation of gravitation and electricity
     year: '1941'
   qc6CJjYAAAAJ:viPVbuMW504C:
-    citations: 402
+    citations: 404
     title: Collected Scientific Works
     year: '1965'
   qc6CJjYAAAAJ:viTTOddtVMkC:
@@ -3938,7 +3938,7 @@ papers:
     title: IDEAS PARA MEDITAR CON CALMA
     year: Unknown Year
   qc6CJjYAAAAJ:vj8KeYadoLsC:
-    citations: 71
+    citations: 73
     title: Diskussion
     year: '1920'
   qc6CJjYAAAAJ:vjZqxyZ7hS4C:
@@ -3970,7 +3970,7 @@ papers:
     title: "Introduction aux th\xE8ories de M. Einstein en vue de leur application a l'astronomie"
     year: '1921'
   qc6CJjYAAAAJ:vytXtR8tOLIC:
-    citations: 3277
+    citations: 3357
     title: B. preuss
     year: '1916'
   qc6CJjYAAAAJ:vzY-6mMDyDUC:
@@ -3986,7 +3986,7 @@ papers:
     title: Considerations on electrodynamics, the ether, geometry and relativity
     year: '1972'
   qc6CJjYAAAAJ:w2UhwfzvF0QC:
-    citations: 428
+    citations: 430
     title: On a generalization of Kaluza's theory of electricity
     year: '1938'
   qc6CJjYAAAAJ:w7CBUyPWg-0C:
@@ -4018,7 +4018,7 @@ papers:
     title: "La teoria della relativit\xE0"
     year: '1987'
   qc6CJjYAAAAJ:wgKq3sYidysC:
-    citations: 528
+    citations: 533
     title: Concerning an heuristic point of view toward the emission and transformation of light
     year: '1965'
   qc6CJjYAAAAJ:wkm4DBaukwsC:
@@ -4030,7 +4030,7 @@ papers:
     title: 'Albert Einstein] to Michele Besso: Letter, 6 Sep 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:wuD5JclIwkYC:
-    citations: 238
+    citations: 243
     title: Science and religion
     year: '1940'
   qc6CJjYAAAAJ:wy5MF_2MSNEC:
@@ -4058,7 +4058,7 @@ papers:
     title: "Briefe zur Wellenmechanik [von][Erwin] Schr\xF6dinger,[Max] Planck,[ALbert] Einstein und [Hendrik Antoon] Lorentz"
     year: '1963'
   qc6CJjYAAAAJ:xvKSgulxyWUC:
-    citations: 795
+    citations: 797
     title: 'The collected papers of Albert Einstein: writings, 1912-1914. The Swiss years'
     year: '1966'
   qc6CJjYAAAAJ:xwIxJehhd2UC:
@@ -4066,7 +4066,7 @@ papers:
     title: "Albert Einstein] to Rudolf F\xF6rster: Letter, 19 Feb 1918"
     year: Unknown Year
   qc6CJjYAAAAJ:xyKys1DtkaQC:
-    citations: 75
+    citations: 78
     title: Wissenschaftlicher Briefwechsel mit Bohr, Einstein, Heisenberg ua. Bd. 4. 1955-1956
     year: '2001'
   qc6CJjYAAAAJ:yCjxvIMm6_oC:
@@ -4078,11 +4078,11 @@ papers:
     title: 'Albert Einstein] to Gustav Mie: Letter, 29 Dec 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:yIeBiWEAh44C:
-    citations: 1344
+    citations: 1351
     title: "\xDCber den Einflu\xDF der Schwerkraft auf die Ausbreitung des Lichtes"
     year: '2006'
   qc6CJjYAAAAJ:yJjnfzR0HrkC:
-    citations: 894
+    citations: 902
     title: Strahlungs-emission und absorption nach der quantentheorie
     year: '1916'
   qc6CJjYAAAAJ:yKZlB_2wKysC:
@@ -4090,11 +4090,11 @@ papers:
     title: 'Albert Einstein] to Paul Ehrenfest: Letter, 4 Sep 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:yNlG6JgpFqoC:
-    citations: 236
+    citations: 237
     title: A generalized theory of gravitation
     year: '1948'
   qc6CJjYAAAAJ:yNohvu9kXXYC:
-    citations: 443
+    citations: 446
     title: Quantentheorie des idealen einatomigen Gases, Sitzber
     year: '1924'
   qc6CJjYAAAAJ:yS0fcbgecPsC:
@@ -4102,7 +4102,7 @@ papers:
     title: Education for independent thought
     year: '1952'
   qc6CJjYAAAAJ:yXZqsUWzai8C:
-    citations: 145
+    citations: 146
     title: "Koniglich Preu\u03B2ische Akademie der Wissenschaften"
     year: '1916'
   qc6CJjYAAAAJ:yZoBfgUKqwcC:

--- a/_data/citations.yml
+++ b/_data/citations.yml
@@ -1,5 +1,5 @@
 metadata:
-  last_updated: '2026-06-17'
+  last_updated: '2026-06-22'
 papers:
   qc6CJjYAAAAJ:-1WLWRmjvKAC:
     citations: 4
@@ -18,7 +18,7 @@ papers:
     title: 'The Palestine Troubles: Einstein''s Protest, Zionism''s Basis and Achievement; the Mandatory''s Task'
     year: '1929'
   qc6CJjYAAAAJ:-LHtoeeytlUC:
-    citations: 2562
+    citations: 2563
     title: 'Albert Einstein: Philosopher Scientist'
     year: '1969'
   qc6CJjYAAAAJ:-R_Z4shfoosC:
@@ -30,7 +30,7 @@ papers:
     title: The special theory of relativity
     year: '1905'
   qc6CJjYAAAAJ:-_cDHGlXAtsC:
-    citations: 8483
+    citations: 8494
     title: Sitzungsberichte der Preussischen Akad. d
     year: '1917'
   qc6CJjYAAAAJ:-fj4grS0xi0C:
@@ -42,7 +42,7 @@ papers:
     title: Brownian motion
     year: '1936'
   qc6CJjYAAAAJ:-qpA3cGbmHsC:
-    citations: 546
+    citations: 548
     title: On the Relation between the Expansion and the Mean Density of the Universe
     year: '1932'
   qc6CJjYAAAAJ:-vzq6BoH5oUC:
@@ -134,7 +134,7 @@ papers:
     title: "L'\xE9ther et la th\xE9orie de la relativit\xE9"
     year: '1921'
   qc6CJjYAAAAJ:1DhOeZtQFr0C:
-    citations: 496
+    citations: 498
     title: Principle Points of the General Theory of Relativity
     year: '1918'
   qc6CJjYAAAAJ:1EM7I_rJWO4C:
@@ -194,7 +194,7 @@ papers:
     title: "Die Einstein-Sammlung der ETH-Bibliothek in Z\xFCrich: ein Ueberblick f\xFCr Ben\xFCtzer der Handschriften-Abteilung"
     year: '1970'
   qc6CJjYAAAAJ:2C0LhDdYSbcC:
-    citations: 1533
+    citations: 1534
     title: "Le principe de relativit\xE9 et ses cons\xE9quences dans la physique moderne"
     year: '1910'
   qc6CJjYAAAAJ:2KloaMYe4IUC:
@@ -210,7 +210,7 @@ papers:
     title: 'Albert Einstein] to Conrad Habicht: Letter, 15 Apr 1904'
     year: Unknown Year
   qc6CJjYAAAAJ:2ZctHUgIzyAC:
-    citations: 473
+    citations: 474
     title: "La g\xE9om\xE9trie et l'exp\xE9rience"
     year: '1921'
   qc6CJjYAAAAJ:2hfDYGh-f1UC:
@@ -258,7 +258,7 @@ papers:
     title: Relativity in Newtonian Mechanics and the Michelson-Morley Experiment
     year: Unknown Year
   qc6CJjYAAAAJ:3vbIHxFL9FgC:
-    citations: 351
+    citations: 352
     title: "Experimenteller Nachweis der Amp\xE8reschen Molekularstr\xF6me"
     year: '1915'
   qc6CJjYAAAAJ:3z7foVzkq2cC:
@@ -270,7 +270,7 @@ papers:
     title: Nachtrag zu meiner Arbeit:Thermodynamische Begruendung des photochemischen Aequivalentgesetzes'(from Annalen der Physik 1912)
     year: '1993'
   qc6CJjYAAAAJ:4Bh_hC5jS3YC:
-    citations: 7157
+    citations: 7161
     title: Graviton Mass and Inertia Mass
     year: '1911'
   qc6CJjYAAAAJ:4DMP91E08xMC:
@@ -290,7 +290,7 @@ papers:
     title: 'Albert Einstein] to Mileva Einstein-Maric: Letter, 17 Apr 1908'
     year: Unknown Year
   qc6CJjYAAAAJ:4JMBOYKVnBMC:
-    citations: 2999
+    citations: 3000
     title: Quantentheorie des einatomigen idealen Gases
     year: '1924'
   qc6CJjYAAAAJ:4QKQTXcH0q8C:
@@ -346,7 +346,7 @@ papers:
     title: 'Einstein, the Man and His Achievement: A Series of Broadcast Talks'
     year: '1967'
   qc6CJjYAAAAJ:5-tCjTwfAdEC:
-    citations: 462
+    citations: 463
     title: "Die Relativit\xE4tstheorie"
     year: '1915'
   qc6CJjYAAAAJ:5Hlrm_bZEgcC:
@@ -386,11 +386,11 @@ papers:
     title: 'Albert Einstein] to Emil Beck: Letter, 30 Apr 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:5bGIVMdsOr0C:
-    citations: 173
+    citations: 174
     title: My theory
     year: '1919'
   qc6CJjYAAAAJ:5pGZGXnFQ_sC:
-    citations: 10670
+    citations: 10686
     title: Sitzungsber. K
     year: '1925'
   qc6CJjYAAAAJ:5qfkUJPXOUwC:
@@ -438,7 +438,7 @@ papers:
     title: "Conceptos, ambientes de aprendizaje:\xBF c\xF3mo aprendemos los humanos en diferentes contextos? Waleska Aldana Segura"
     year: Unknown Year
   qc6CJjYAAAAJ:6ftYtcnYaCAC:
-    citations: 344
+    citations: 345
     title: Ather and Relativitatstheorie. J
     year: '1920'
   qc6CJjYAAAAJ:6gD0efnhv6MC:
@@ -458,7 +458,7 @@ papers:
     title: "Bietet die feldtheorie M\xF6glichkeiten f\xFCr die L\xF6sung des Quantenproblems?"
     year: '1923'
   qc6CJjYAAAAJ:7DJsn6tmoAwC:
-    citations: 331
+    citations: 332
     title: "\xC4ther und Relativit\xE4ts-theorie"
     year: '1920'
   qc6CJjYAAAAJ:7DTIKO_nxaIC:
@@ -566,7 +566,7 @@ papers:
     title: "Die Einstein-Dokumente im Archiv der Humboldt-Universit\xE4t zu Berlin"
     year: '1973'
   qc6CJjYAAAAJ:94rQ0kDLHKYC:
-    citations: 4587
+    citations: 4586
     title: Evolution of Physics
     year: '1954'
   qc6CJjYAAAAJ:9CGX2owmTHMC:
@@ -582,7 +582,7 @@ papers:
     title: Elementare Uberlegungen zur Interpretation der Grundlagen der Quanten-Mechanik
     year: '1953'
   qc6CJjYAAAAJ:9PbDelcLwNgC:
-    citations: 35
+    citations: 36
     title: On the theory of light production and light absorption
     year: '1906'
   qc6CJjYAAAAJ:9QTmwX2E1jEC:
@@ -686,7 +686,7 @@ papers:
     title: "Albert Ajn\u0161tajn: njegova dela i njihov uticaj na na\u0161 svet"
     year: '1957'
   qc6CJjYAAAAJ:B2rIPIGFPLEC:
-    citations: 37
+    citations: 39
     title: Bivector fields
     year: '1944'
   qc6CJjYAAAAJ:B3FOqHPlNUQC:
@@ -718,7 +718,7 @@ papers:
     title: VI. GRAVITATIONAL WAVES
     year: '1979'
   qc6CJjYAAAAJ:BjLbhSWBl98C:
-    citations: 224
+    citations: 223
     title: "Experimental proof of the existence of Amp\xE8re's molecular currents"
     year: '1915'
   qc6CJjYAAAAJ:BnRbUGEozz8C:
@@ -766,7 +766,7 @@ papers:
     title: 'Albert Einstein] to Paul Seippel: Letter, 19 Aug 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:CLQ-NLsb8zAC:
-    citations: 3172
+    citations: 3173
     title: Ideas and Opinions
     year: '1954'
   qc6CJjYAAAAJ:COU-sansr_wC:
@@ -774,7 +774,7 @@ papers:
     title: "Elie Cartan-Albert Einstein: lettres sur le parall\xE9lisme absolu 1929-1932"
     year: '1979'
   qc6CJjYAAAAJ:CQX_Vi8q7s0C:
-    citations: 1969
+    citations: 1971
     title: Introduction Einstein's Relativity
     year: '1992'
   qc6CJjYAAAAJ:CRQ797xmLJIC:
@@ -790,11 +790,11 @@ papers:
     title: "Untersuchungen \xFCber die Theorie der Brownschen Bewegung/Abhandlungen \xFCber die Brownsche Bewegung und verwandte Erscheinungen"
     year: '1999'
   qc6CJjYAAAAJ:CY3uIpTmi-gC:
-    citations: 152
+    citations: 150
     title: Einstein on Cosmic Religion and Other Opinions and Aphorisms
     year: '2009'
   qc6CJjYAAAAJ:CmbFvBriOyMC:
-    citations: 189
+    citations: 191
     title: "O significado da relatividade: com a teoria relativista do campo n\xE3o sim\xE9trico"
     year: '1958'
   qc6CJjYAAAAJ:CmeMDzcFUg4C:
@@ -814,7 +814,7 @@ papers:
     title: On the moral obligation of the scientist
     year: '1945'
   qc6CJjYAAAAJ:Cv-mv52rCCkC:
-    citations: 5318
+    citations: 5327
     title: On the motion of particles suspended in a liquid at rest, assumed by the molecular-kinetic theory of heat
     year: '1905'
   qc6CJjYAAAAJ:Cx2ibDnldiAC:
@@ -858,7 +858,7 @@ papers:
     title: Jarbuch der Radioaktivitat und Elektronik, 4, 411 (1907), reprinted in The Collected Papers of A. Einstein, vol. 2, 252
     year: '1989'
   qc6CJjYAAAAJ:DQNrXyjhriIC:
-    citations: 3140
+    citations: 3147
     title: Die feldgleichungen der gravitation
     year: '1915'
   qc6CJjYAAAAJ:D_sINldO8mEC:
@@ -938,7 +938,7 @@ papers:
     title: 'Albert Einstein] to Romain Rolland: Letter, 22 Mar 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:EYYDruWGBe4C:
-    citations: 228
+    citations: 227
     title: "The Collected Papers of Albert Einstein, Vol. 2, The Swiss Years: Writings, 1900\u20131909 (English Translation Supplement)"
     year: '1989'
   qc6CJjYAAAAJ:Ecsxi449JjsC:
@@ -986,7 +986,7 @@ papers:
     title: 'Einstein: Science and Religion'
     year: Unknown Year
   qc6CJjYAAAAJ:FKYJxdYMdFIC:
-    citations: 1002
+    citations: 999
     title: "The Collected Papers of Albert Einstein, Volume 15 (Translation Supplement): The Berlin Years: Writings & Correspondence, June 1925\u2013May 1927"
     year: '2018'
   qc6CJjYAAAAJ:FKzTm0Bp8ZYC:
@@ -1118,11 +1118,11 @@ papers:
     title: 'Zitate Aus Mein Weltbild: Sieben Radierungen Von Terry Haass'
     year: '1975'
   qc6CJjYAAAAJ:Gpwnp1kGG20C:
-    citations: 258
+    citations: 259
     title: Ernst Mach
     year: '1916'
   qc6CJjYAAAAJ:Grx829lh2T4C:
-    citations: 3109
+    citations: 3110
     title: Quantum theory of monatomic ideal gases
     year: '1924'
   qc6CJjYAAAAJ:GsgvGxwuA5UC:
@@ -1154,7 +1154,7 @@ papers:
     title: Science Fiction and Fantasy
     year: '1980'
   qc6CJjYAAAAJ:H4IpxOyCX80C:
-    citations: 179
+    citations: 180
     title: "L'\xE9volution des id\xE9es en physique"
     year: '1963'
   qc6CJjYAAAAJ:HKviVsUxM5wC:
@@ -1178,11 +1178,11 @@ papers:
     title: Riemann-Metrik mit Aufrechterhaltung des Begriffes der Fern-parallelismus, Preuss
     year: '1928'
   qc6CJjYAAAAJ:HklM7qHXWrUC:
-    citations: 462
+    citations: 463
     title: "Die Relativit\xE4tstheorie"
     year: '1925'
   qc6CJjYAAAAJ:Hl4CZ0n6gBQC:
-    citations: 21740
+    citations: 21750
     title: Uber einen die Erzeugung und Verwandlung des Lichtes betreffenden heurischen Gesichtpunkt
     year: '1905'
   qc6CJjYAAAAJ:HtEfBTGE9r8C:
@@ -1194,7 +1194,7 @@ papers:
     title: 'Science: Conjectures and Refutations'
     year: '1997'
   qc6CJjYAAAAJ:HygtOXotxAUC:
-    citations: 44
+    citations: 43
     title: "Sur l'\xE9lectrodynamique des corps en mouvement"
     year: '1925'
   qc6CJjYAAAAJ:I6TX2FUo6loC:
@@ -1206,11 +1206,11 @@ papers:
     title: Zur Abwehr
     year: '1921'
   qc6CJjYAAAAJ:I9gX6wnfuA8C:
-    citations: 334
+    citations: 335
     title: "\xC4ther und Relativit\xE4tstheorie: Rede gehalten am 5. Mai 1920 an der Reichs-Universit\xE4t zu Leiden"
     year: '1920'
   qc6CJjYAAAAJ:IEpB_1CIIT4C:
-    citations: 3954
+    citations: 3953
     title: 'THE EVOLUTION OF PHYSICS: THE GROWTH OF IDEAS FROM THE EARLY CON CEPTS TO RELATIVITY AND QUANTA.'
     year: '1938'
   qc6CJjYAAAAJ:IHkkN1K1AlAC:
@@ -1258,7 +1258,7 @@ papers:
     title: 'Zu Max Plancks sechzegstem Geburtstag: Ansprachen, gehalten am 26. April 1918 in der Deutschen Physikalischen Gesellschaft'
     year: '1918'
   qc6CJjYAAAAJ:IqrShC7OVU0C:
-    citations: 6515
+    citations: 6518
     title: Investigations on the theory of the Brownian movement, edited with notes by R
     year: '1926'
   qc6CJjYAAAAJ:IvSMUa3B7yYC:
@@ -1266,7 +1266,7 @@ papers:
     title: "Berichtigung zur Abhandlung:\u201E\xDCber die elektromagnetischen Grundgleichungen f\xFCr bewegte K\xF6rper\u201D \uFE01"
     year: '1908'
   qc6CJjYAAAAJ:J-pR_7NvFogC:
-    citations: 848
+    citations: 847
     title: 'The Swiss Years: Writings, 1914-1917'
     year: '1996'
   qc6CJjYAAAAJ:J4wmHkHhN-kC:
@@ -1278,7 +1278,7 @@ papers:
     title: Tables of Einstein Functions
     year: '1962'
   qc6CJjYAAAAJ:JQPmwQThujIC:
-    citations: 473
+    citations: 474
     title: "La g\xE9om\xE9trie et l'exp\xE9rience, par Albert Einstein; traduit par Maurice Solovine"
     year: '1921'
   qc6CJjYAAAAJ:JXi_AgyUMBAC:
@@ -1286,7 +1286,7 @@ papers:
     title: Relativistic theory of the non-symmetric field
     year: '1955'
   qc6CJjYAAAAJ:JZsVLox4iN8C:
-    citations: 2471
+    citations: 2472
     title: 'Autobiographisches in: Albert Einstein: Philosopher-Scientist'
     year: '1949'
   qc6CJjYAAAAJ:J_g5lzvAfSwC:
@@ -1314,7 +1314,7 @@ papers:
     title: Fundamental ideas and problems of the theory of relativity
     year: '2009'
   qc6CJjYAAAAJ:K4-iKlO5MD4C:
-    citations: 764
+    citations: 765
     title: A Heuristic Viewpoint Concerning the Production and Transformation of Light
     year: '1929'
   qc6CJjYAAAAJ:K6kyChav4UkC:
@@ -1342,7 +1342,7 @@ papers:
     title: Why socialism?
     year: '1951'
   qc6CJjYAAAAJ:KOc9rAu6-V4C:
-    citations: 409
+    citations: 410
     title: letter to Max Born
     year: '1926'
   qc6CJjYAAAAJ:KQ7zX_ltr48C:
@@ -1390,7 +1390,7 @@ papers:
     title: 'Albert Einstein] to Mileva Einstein-Maric: Letter, after 17 Mar 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:L7JqRCIhofwC:
-    citations: 6877
+    citations: 6884
     title: Sitzungsberichte der Preussischen Akademie der Wissenschaften zu Berlin
     year: '1915'
   qc6CJjYAAAAJ:L7vk9XBBNxgC:
@@ -1454,11 +1454,11 @@ papers:
     title: 'Albert Einstein] to Hedwig Born: Letter, 8 Feb 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:LkGwnXOMwfcC:
-    citations: 3236
+    citations: 3245
     title: The foundation of the general theory of relativity
     year: '1916'
   qc6CJjYAAAAJ:LkrQC8aPkXYC:
-    citations: 5461
+    citations: 5474
     title: 'Relativity: The Special and the General Theory: a Popular Exposition by Albert Einstein; Transl. by Robert W. Lawson'
     year: '1961'
   qc6CJjYAAAAJ:Lmuc1furtc4C:
@@ -1506,15 +1506,15 @@ papers:
     title: Two-body problem in general relativity theory
     year: '1936'
   qc6CJjYAAAAJ:M3ejUd6NZC8C:
-    citations: 491
+    citations: 493
     title: "Prinzipielles zur allgemeinen Relativit\xE4tstheorie"
     year: '1918'
   qc6CJjYAAAAJ:M8meJADSprsC:
-    citations: 189
+    citations: 191
     title: El significado de la relatividad
     year: '1971'
   qc6CJjYAAAAJ:MDX3w3dAD3YC:
-    citations: 920
+    citations: 919
     title: Zum quantensatz von Sommerfeld und Epstein
     year: '1917'
   qc6CJjYAAAAJ:MGPUR4WVBMEC:
@@ -1526,7 +1526,7 @@ papers:
     title: New possibility for a unified field theory of gravitation and electricity
     year: '1928'
   qc6CJjYAAAAJ:MNNNGtAgD4EC:
-    citations: 343
+    citations: 346
     title: "Bemerkung zu dem Gesetz von E\xF6tv\xF6s"
     year: '1911'
   qc6CJjYAAAAJ:MTuJV9umhWMC:
@@ -1570,7 +1570,7 @@ papers:
     title: The advent of the quantum theory
     year: '1951'
   qc6CJjYAAAAJ:NM66qo_NnlUC:
-    citations: 1034
+    citations: 1032
     title: 'The Collected Papers of Albert Einstein: English Translation'
     year: '1989'
   qc6CJjYAAAAJ:NMxIlDl6LWMC:
@@ -1630,7 +1630,7 @@ papers:
     title: 'Albert Einstein] to Wilhelm Wien: Letter, 17 Oct 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:Nw_I7GeUguwC:
-    citations: 168
+    citations: 167
     title: "Zur allgemeinen molekularen Theorie der W\xE4rme"
     year: '1904'
   qc6CJjYAAAAJ:NzUpm4bhSXQC:
@@ -1638,7 +1638,7 @@ papers:
     title: "Die Quantentheorie der spezifischen W\xE4rme"
     year: '1967'
   qc6CJjYAAAAJ:O0MA3yP7Y3UC:
-    citations: 309
+    citations: 308
     title: 'The Collected Papers of Albert Einstein, Volume 8: The Berlin Years: Correspondence, 1914-1918.'
     year: '1998'
   qc6CJjYAAAAJ:O3NaXMp0MMsC:
@@ -1662,7 +1662,7 @@ papers:
     title: 'Friedrich Wilhelm Foerster und Albert Einstein: Briefwechsel von 1935 bis 1954'
     year: '2001'
   qc6CJjYAAAAJ:OPs5gEIPXMUC:
-    citations: 8367
+    citations: 8383
     title: On gravitational waves Sitzungsber. preuss
     year: '1918'
   qc6CJjYAAAAJ:OTTXONDVkokC:
@@ -1670,7 +1670,7 @@ papers:
     title: On the relativity problem
     year: '2007'
   qc6CJjYAAAAJ:OVe_t5h5bhEC:
-    citations: 277
+    citations: 278
     title: "Mi visi\xF3n del mundo"
     year: '1985'
   qc6CJjYAAAAJ:Oi-j_DTgP3cC:
@@ -1694,7 +1694,7 @@ papers:
     title: On German Literature for Viola Da Gamba in the 16th and 17th Centuries
     year: '1977'
   qc6CJjYAAAAJ:P1qO8dLd1z8C:
-    citations: 275
+    citations: 273
     title: The Photoelectric Effect
     year: '1905'
   qc6CJjYAAAAJ:P9oYG7HA76QC:
@@ -1734,7 +1734,7 @@ papers:
     title: 'Wissenschaftlicher Briefwechsel Mit Bohr, Einstein, Heisenberg, Ua: Scientific Correspondence with Bohr, Einstein, Heisenberg, Ao Volume 1: 1919-1929. 1919-1929'
     year: '1979'
   qc6CJjYAAAAJ:Q7hiZQKJ-pAC:
-    citations: 226
+    citations: 228
     title: 'Cosmic religion: with other opinions and aphorisms'
     year: '1931'
   qc6CJjYAAAAJ:Q9ss7R9eeXsC:
@@ -1758,7 +1758,7 @@ papers:
     title: "Cien a\xF1os de relatividad: Los art\xEDculos de Albert Einstein de 1905 y 1906"
     year: '2004'
   qc6CJjYAAAAJ:QIV2ME_5wuYC:
-    citations: 773
+    citations: 777
     title: Does the inertia of a body depend upon its energy-content?
     year: '1905'
   qc6CJjYAAAAJ:QKtdBID3u5MC:
@@ -1854,7 +1854,7 @@ papers:
     title: Bemerkungen iiber den Wandel der Problemstcllungen in der theoretischen Physik
     year: Unknown Year
   qc6CJjYAAAAJ:RfUwGJFMQ-0C:
-    citations: 4550
+    citations: 4552
     title: Zur quantentheorie der strahlung
     year: '1917'
   qc6CJjYAAAAJ:RgMnzfD6kpIC:
@@ -1878,7 +1878,7 @@ papers:
     title: "Kinetische Theorie des W\xE4rmegleichgewichtes und des zweiten Hauptsatzes der Thermodynamik"
     year: '1902'
   qc6CJjYAAAAJ:S9V7H-Nz35UC:
-    citations: 7789
+    citations: 7777
     title: On a Heuristic Point of View Toward the Emission and Transformation of Light
     year: '1905'
   qc6CJjYAAAAJ:SFOYbPikdlgC:
@@ -1938,7 +1938,7 @@ papers:
     title: 'Albert Einstein] to Wladyslaw Natanson: Letter, 24 Aug 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:SzsLJvG5eXAC:
-    citations: 2041
+    citations: 2042
     title: Autobiographical Notes, ed
     year: '1979'
   qc6CJjYAAAAJ:T64LSalLz9oC:
@@ -1958,11 +1958,11 @@ papers:
     title: Letters on wave mechanics
     year: '1967'
   qc6CJjYAAAAJ:TGemctCAZTQC:
-    citations: 35
+    citations: 34
     title: The new field theory
     year: '1929'
   qc6CJjYAAAAJ:TIZ-Mc8IlK0C:
-    citations: 1112
+    citations: 1114
     title: On the method of theoretical physics
     year: '1934'
   qc6CJjYAAAAJ:TKTY8N1AUUAC:
@@ -1990,7 +1990,7 @@ papers:
     title: "Hamilton\u2019s principle and the general theory of relativity"
     year: '1916'
   qc6CJjYAAAAJ:TiIbgCYny7sC:
-    citations: 9470
+    citations: 9478
     title: "Zur Elektrodynamik bewegter K\xF6rper"
     year: Unknown Year
   qc6CJjYAAAAJ:TmnWbB_axlEC:
@@ -2146,7 +2146,7 @@ papers:
     title: 'The collected papers of Albert Einstein. Vol 6, The Berlin years: writings, 1914-1917:[English translation]'
     year: '2002'
   qc6CJjYAAAAJ:VyOdxF-JhwgC:
-    citations: 257
+    citations: 260
     title: SB preuss
     year: '1916'
   qc6CJjYAAAAJ:VyewGSb6xwwC:
@@ -2162,7 +2162,7 @@ papers:
     title: "L'\xE9tat actuel du probl\xE8me des chaleurs sp\xE9cifiques"
     year: '1912'
   qc6CJjYAAAAJ:W7OEmFMy1HYC:
-    citations: 1640
+    citations: 1643
     title: Lens-like action of a star by the deviation of light in the gravitational field
     year: '1936'
   qc6CJjYAAAAJ:WC4w5-ZrDNIC:
@@ -2174,7 +2174,7 @@ papers:
     title: La discussion Einstein-Bohr.
     year: Unknown Year
   qc6CJjYAAAAJ:WF5omc3nYNoC:
-    citations: 1062
+    citations: 1064
     title: On gravitational waves
     year: '1937'
   qc6CJjYAAAAJ:WIVIxizkzXoC:
@@ -2274,7 +2274,7 @@ papers:
     title: 'Albert Einstein] to Paul Gruner: Letter, 11 Feb 1908'
     year: Unknown Year
   qc6CJjYAAAAJ:XZvG1uL-wj0C:
-    citations: 1160
+    citations: 1162
     title: 'On the method of theoretical physics: The Herbert Spencer lecture, delivered at Oxford 10 June 1933'
     year: '1933'
   qc6CJjYAAAAJ:Xc-mKOjpdrwC:
@@ -2286,7 +2286,7 @@ papers:
     title: 'The Collected Papers of Albert Einstein, Volume 9: The Berlin Years: Correspondence, January 1919-April 1920'
     year: '2004'
   qc6CJjYAAAAJ:XdwVV_xN3QMC:
-    citations: 1536
+    citations: 1539
     title: Draft of a Generalized Theory of Relativity and a Theory of Gravitation
     year: '1913'
   qc6CJjYAAAAJ:XeErXHja3Z8C:
@@ -2322,7 +2322,7 @@ papers:
     title: "Research@ FrankfurtSchool in Zeiten der Finanzmarktkrise \u201EA Collection of Working Papers \u201C"
     year: Unknown Year
   qc6CJjYAAAAJ:Y0agIcFmOsQC:
-    citations: 1207
+    citations: 1208
     title: A correction on my work-A new determination of molecular dimensions
     year: '1969'
   qc6CJjYAAAAJ:Y1W0x10ZrwMC:
@@ -2382,7 +2382,7 @@ papers:
     title: Physics, philosophy and scientific progress.
     year: '1950'
   qc6CJjYAAAAJ:YoqGh_aPxy4C:
-    citations: 80
+    citations: 81
     title: The common language of science
     year: '1941'
   qc6CJjYAAAAJ:YpRCXavlr0AC:
@@ -2390,7 +2390,7 @@ papers:
     title: 'Albert Einstein] to Michele and Anna Besso-Winteler: Letter, 1 Aug 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:YsMSGLbcyi4C:
-    citations: 2404
+    citations: 2407
     title: The particle problem in the general theory of relativity
     year: '1935'
   qc6CJjYAAAAJ:YvgfBAebZEkC:
@@ -2430,7 +2430,7 @@ papers:
     title: 'Briefwechsel: Sechzig Briefe aus dem goldenen Zeitalter der modernen Physik'
     year: '1968'
   qc6CJjYAAAAJ:ZbQVaL1IMbQC:
-    citations: 4097
+    citations: 4102
     title: Quanzeml~ orie der stralllung
     year: '1916'
   qc6CJjYAAAAJ:ZbiiB1Sm8G8C:
@@ -2458,7 +2458,7 @@ papers:
     title: 'Relativiteit: speciale en algemene theorie'
     year: '1986'
   qc6CJjYAAAAJ:Zph67rFs4hoC:
-    citations: 399
+    citations: 398
     title: "Grundz\xFCge der Relativit\xE4tstheorie"
     year: '2002'
   qc6CJjYAAAAJ:ZppSRAJs3i8C:
@@ -2518,7 +2518,7 @@ papers:
     title: A generalization of the relativistic theory of gravitation
     year: '1945'
   qc6CJjYAAAAJ:_mQi-xiA4oYC:
-    citations: 462
+    citations: 463
     title: "Die Relativit\xE4ts-Theorie"
     year: '1911'
   qc6CJjYAAAAJ:a2necdfpwlEC:
@@ -2526,7 +2526,7 @@ papers:
     title: "Eine Beziehung zwischen dem elastischen Verhalten und der spezifischen W\xE4rme bei festen K\xF6rpern mit einatomigem Molek\xFCl"
     year: '1911'
   qc6CJjYAAAAJ:a9-T7VOCCH8C:
-    citations: 3805
+    citations: 3807
     title: The Science and the Life of Albert Einstein
     year: '1982'
   qc6CJjYAAAAJ:aDdGf5um_jkC:
@@ -2534,7 +2534,7 @@ papers:
     title: 'Albert Einstein] to Gustav Mie: Letter, 2 Jun 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:aEPHIGigqugC:
-    citations: 4356
+    citations: 4358
     title: "Physics and Reality, in \u201CIdeas and Opinions\u201D"
     year: '1954'
   qc6CJjYAAAAJ:aEyKTaVlRPYC:
@@ -2550,7 +2550,7 @@ papers:
     title: 'Essays in Science (New York: Philosophical Library, 1934)'
     year: Unknown Year
   qc6CJjYAAAAJ:aXI_bbQgCfgC:
-    citations: 174
+    citations: 175
     title: "Die Ursache der M\xE4anderbildung der Flu\xDFl\xE4ufe und des sogenannten Baerschen Gesetzes"
     year: '1926'
   qc6CJjYAAAAJ:aXwx4OqTWR4C:
@@ -2574,7 +2574,7 @@ papers:
     title: "Neue M\xF6glichkeit f\xFCr eine einheitliche Feldtheorie von Gravitation und Elektrizit\xE4t"
     year: '1928'
   qc6CJjYAAAAJ:adgdM4TzidAC:
-    citations: 44
+    citations: 43
     title: "Sur l'\xE9lectrodynamique des corps en mouvement"
     year: '1905'
   qc6CJjYAAAAJ:ae0xyBWlIcIC:
@@ -2602,11 +2602,11 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 26 Nov 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:bCjgOgSFrM0C:
-    citations: 1286
+    citations: 1285
     title: "Die plancksche theorie der strahlung und die theorie der spezifischen w\xE4rme"
     year: '1906'
   qc6CJjYAAAAJ:bEWYMUwI8FkC:
-    citations: 286
+    citations: 289
     title: Why war?
     year: '1933'
   qc6CJjYAAAAJ:bFuYayV9R1gC:
@@ -2686,7 +2686,7 @@ papers:
     title: The Fight Against War
     year: '1933'
   qc6CJjYAAAAJ:c4A-nLdbYHEC:
-    citations: 1560
+    citations: 1561
     title: 'Concepts of space: The history of theories of space in physics'
     year: '1969'
   qc6CJjYAAAAJ:c5LcigzBm8MC:
@@ -2702,7 +2702,7 @@ papers:
     title: 'In Memory of Emmy Noether...: Abstract of Address Delivered by Professor Hermann Weyl... and Copy of Letter of Professor Albert Einstein'
     year: '1935'
   qc6CJjYAAAAJ:cNe27ouKFcQC:
-    citations: 7839
+    citations: 7862
     title: "Die grundlage der allgemeinen relativit\xE4tstheorie"
     year: '2006'
   qc6CJjYAAAAJ:cOfwuRB03ygC:
@@ -2710,11 +2710,11 @@ papers:
     title: "Die spezielle relativit\xE4tstheorie Einsteins und die logik"
     year: '1924'
   qc6CJjYAAAAJ:cRMvf6lLvU8C:
-    citations: 292
+    citations: 293
     title: "Einige Argumente f\xFCr die Annahme einer molekularen Agitation beim absoluten Nullpunkt"
     year: '1913'
   qc6CJjYAAAAJ:cSdaV2aYdYsC:
-    citations: 376
+    citations: 379
     title: Spielen Gravitationsfelder im Aufbau der materiellen Elementarteilchen eine wesentliche Rolle?
     year: '1919'
   qc6CJjYAAAAJ:cTdzRpWJKHEC:
@@ -2782,7 +2782,7 @@ papers:
     title: "Correspondence 1903\u20131955, ed"
     year: '1972'
   qc6CJjYAAAAJ:dTyEYWd-f8wC:
-    citations: 179
+    citations: 180
     title: "L'\xE9volution des id\xE9es en physique: des premiers concepts aux th\xE9ories de la relativit\xE9 et des quanta"
     year: '1948'
   qc6CJjYAAAAJ:dX-nQPao9noC:
@@ -2826,7 +2826,7 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 4 Nov 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:e84hm74t-eoC:
-    citations: 5812
+    citations: 5815
     title: "Eine neue bestimmung der molek\xFCldimensionen"
     year: '1906'
   qc6CJjYAAAAJ:eAUscmXIlQ8C:
@@ -2910,7 +2910,7 @@ papers:
     title: "Sushchnost\u02B9 teorii otnositel\u02B9nosti: Perevod s angli\u012Dskogo"
     year: '1955'
   qc6CJjYAAAAJ:fEOibwPWpKIC:
-    citations: 123
+    citations: 124
     title: "\xDCber den \xC4ther"
     year: '1924'
   qc6CJjYAAAAJ:fHS53ZCY-AEC:
@@ -2918,7 +2918,7 @@ papers:
     title: 'Albert Einstein] to Kathia Adler: Letter, 20 Feb 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:fLJJVVwU7EQC:
-    citations: 358
+    citations: 359
     title: "Ein einfaches Experiment zum Nachweis der Amp\xE8reschen Molekularstr\xF6me"
     year: '1916'
   qc6CJjYAAAAJ:fPk4N6BV_jEC:
@@ -2966,7 +2966,7 @@ papers:
     title: On the limit of validity of the law of thermodynamic equilibrium and on the possibility of a new determination of the elementary quanta
     year: '1907'
   qc6CJjYAAAAJ:g5m5HwL7SMYC:
-    citations: 147
+    citations: 148
     title: TIME, SPACE, AND GRAVITATION.
     year: '1920'
   qc6CJjYAAAAJ:gKLIUvgTho8C:
@@ -2982,7 +2982,7 @@ papers:
     title: Zu Dr. Berliners siebzigstem Geburtstag
     year: '1932'
   qc6CJjYAAAAJ:gV6rEsy15s0C:
-    citations: 3914
+    citations: 3924
     title: Bemerkungen zu der Arbeit
     year: '1914'
   qc6CJjYAAAAJ:gYAb_yFic6IC:
@@ -3010,7 +3010,7 @@ papers:
     title: "Ejn\u0161tejnovskaja teorija otnosite\u013Enosti"
     year: '1972'
   qc6CJjYAAAAJ:hEXC_dOfxuUC:
-    citations: 395
+    citations: 396
     title: Reply to critics
     year: '1949'
   qc6CJjYAAAAJ:hEp1lTclR2YC:
@@ -3022,7 +3022,7 @@ papers:
     title: "\xDCber die formale Beziehung des Riemannschen Kr\xFCmmungstensors zu den Feldgleichungen der Gravitation"
     year: '1927'
   qc6CJjYAAAAJ:hMod-77fHWUC:
-    citations: 5268
+    citations: 5281
     title: "La relativit\xE9"
     year: '1964'
   qc6CJjYAAAAJ:hMwNgRnlwaMC:
@@ -3030,7 +3030,7 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 10 Sep 1914'
     year: Unknown Year
   qc6CJjYAAAAJ:hTqO-V9ugBQC:
-    citations: 44
+    citations: 43
     title: "Sur l'\xE9lectrodynamique des corps en mouvement"
     year: '1965'
   qc6CJjYAAAAJ:hUq98zRk74IC:
@@ -3038,11 +3038,11 @@ papers:
     title: EddingtonsTheorie und Hamiltonsches Prinzip
     year: '1925'
   qc6CJjYAAAAJ:hVd5agGqjXwC:
-    citations: 3822
+    citations: 3824
     title: Physikalische Gesellschaft Zuerich
     year: '1916'
   qc6CJjYAAAAJ:hbz17DqrwuEC:
-    citations: 351
+    citations: 352
     title: Notiz zu unserer Arbeit
     year: '1915'
   qc6CJjYAAAAJ:hcF2OqvMasEC:
@@ -3102,7 +3102,7 @@ papers:
     title: Geometria no euclidea y fisica
     year: '1926'
   qc6CJjYAAAAJ:i_7YvbSbtFEC:
-    citations: 8906
+    citations: 8915
     title: "Berichtigung zu meiner Arbeit:\u201EEine neue Bestimmung der Molek\xFCldimensionen\u201D \uFE01"
     year: '2006'
   qc6CJjYAAAAJ:ifIdVpG6JtcC:
@@ -3122,7 +3122,7 @@ papers:
     title: "La th\xE9orie de la relativit\xE9 d'Einstein et la dialectique."
     year: Unknown Year
   qc6CJjYAAAAJ:isC4tDSrTZIC:
-    citations: 4294
+    citations: 4304
     title: "\xDCber Gravitationswellen"
     year: '1918'
   qc6CJjYAAAAJ:it4f3qIuXWYC:
@@ -3178,7 +3178,7 @@ papers:
     title: A memorial to PAM Dirac
     year: '1990'
   qc6CJjYAAAAJ:k4O5U3vRA4YC:
-    citations: 5803
+    citations: 5816
     title: The special and general theory
     year: '1920'
   qc6CJjYAAAAJ:k6nH7jlkaTkC:
@@ -3194,7 +3194,7 @@ papers:
     title: Einstein's essays in science
     year: '2009'
   qc6CJjYAAAAJ:kGbpvR7Ecy8C:
-    citations: 38
+    citations: 40
     title: Bivector fields II
     year: '1944'
   qc6CJjYAAAAJ:kMrClmKSQGwC:
@@ -3222,7 +3222,7 @@ papers:
     title: "Albert Einstein] to Walter D\xE4llenbach: Letter, after 15 Feb 1917"
     year: Unknown Year
   qc6CJjYAAAAJ:kqeZabM7ilsC:
-    citations: 7031
+    citations: 7040
     title: Preuss, Sitzungsber
     year: '1915'
   qc6CJjYAAAAJ:l0_JBNIuc60C:
@@ -3234,11 +3234,11 @@ papers:
     title: Court Expert Opinion in the Matter of Signal Co. vs. Atlas Works, ca. 3 Dec 1921
     year: Unknown Year
   qc6CJjYAAAAJ:l6Q3WhenKVUC:
-    citations: 593
+    citations: 592
     title: Geometrie und erfahrung
     year: '1921'
   qc6CJjYAAAAJ:l7t_Zn2s7bgC:
-    citations: 660
+    citations: 663
     title: Ether and the Theory of Relativity
     year: '2007'
   qc6CJjYAAAAJ:lAj_JhtUatoC:
@@ -3254,7 +3254,7 @@ papers:
     title: The collecteds of albert einstein v 9 the berlin years correspondence january 1919-april 1920 english translation (paperback)
     year: '2004'
   qc6CJjYAAAAJ:lEqHes_HPG0C:
-    citations: 798
+    citations: 799
     title: 'The principle of relativity: a collection of original memoirs on the special and general theory of relativity'
     year: '1923'
   qc6CJjYAAAAJ:lIaPce-xyHYC:
@@ -3266,7 +3266,7 @@ papers:
     title: "Grundgedanken und Probleme der Relativit\xE4tstheorie"
     year: '1923'
   qc6CJjYAAAAJ:lLPirIASiZEC:
-    citations: 857
+    citations: 855
     title: "The Collected Papers of Albert Einstein, Volume 15 (Translation Supplement): The Berlin Years: Writings & Correspondence, June 1925\u2013May 1927"
     year: '2018'
   qc6CJjYAAAAJ:lOG7zRu2uA8C:
@@ -3306,7 +3306,7 @@ papers:
     title: A new form of the general relativistic field equations
     year: '1955'
   qc6CJjYAAAAJ:mN77zE6YZBUC:
-    citations: 732
+    citations: 731
     title: Ueber spezielle und allgemeine Relativitaetstheorie, 127
     year: '1969'
   qc6CJjYAAAAJ:mNm_27jwclsC:
@@ -3342,7 +3342,7 @@ papers:
     title: Albert Einstein] to Michele Besso:[A second] letter, 21 Jul 1916
     year: Unknown Year
   qc6CJjYAAAAJ:mnAcAzq93VMC:
-    citations: 124
+    citations: 122
     title: Riemannian Geometry with Maintaining the Notion of distant parallelism
     year: '1928'
   qc6CJjYAAAAJ:mpaOjDK6XBIC:
@@ -3422,7 +3422,7 @@ papers:
     title: "Teor\u0131a cu\xE1ntica de gases ideales monoat\xF3micos, Sitz"
     year: '1924'
   qc6CJjYAAAAJ:o4Qvs5Y5TLQC:
-    citations: 996
+    citations: 993
     title: The Early Years 1879-1902
     year: '1987'
   qc6CJjYAAAAJ:o9ULDYDKYbIC:
@@ -3438,7 +3438,7 @@ papers:
     title: "\xDCber die M\xF6glichkeit einer neuen Pr\xFCfung des Relativit\xE4tsprinzips"
     year: '2006'
   qc6CJjYAAAAJ:oFWWKr2Zb18C:
-    citations: 123
+    citations: 124
     title: On the ether
     year: '1991'
   qc6CJjYAAAAJ:oJZlKik0E8QC:
@@ -3470,7 +3470,7 @@ papers:
     title: "Einheitliche Theorie von Gravitation und Elektrizit\xE4t. Zweite Abhandlung"
     year: '2006'
   qc6CJjYAAAAJ:oqD4_j7ulsYC:
-    citations: 20616
+    citations: 20630
     title: On the movement of small particles suspended in stationary liquids required by the molecular-kinetic theory of heat
     year: '1905'
   qc6CJjYAAAAJ:osi8XriVlOYC:
@@ -3478,7 +3478,7 @@ papers:
     title: 'Albert Einstein] to Wander and Geertruida de Haas: Letter, 6 Jul 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:oursBaop5wYC:
-    citations: 1512
+    citations: 1513
     title: Zur theorie der brownschen bewegung
     year: '1906'
   qc6CJjYAAAAJ:oy0z8GdgWhYC:
@@ -3574,11 +3574,11 @@ papers:
     title: "Quatre conf\xE9rences sur la th\xE9orie de la relativit\xE9 faites \xE0 l'Universit\xE9 de Princeton"
     year: '2005'
   qc6CJjYAAAAJ:qCpRzq7zkD8C:
-    citations: 2217
+    citations: 2220
     title: "Zur allgemeinen Relativit\xE4tstheorie"
     year: '1915'
   qc6CJjYAAAAJ:qPeb-qHga9sC:
-    citations: 309
+    citations: 310
     title: "Auf die Riemann-Metrik und den Fern-Parallelismus gegr\xFCndete einheitliche Feldtheorie"
     year: '1930'
   qc6CJjYAAAAJ:qbqt7gslDFUC:
@@ -3590,11 +3590,11 @@ papers:
     title: "En busca del eslab\xF3n perdido entre educaci\xF3n y desarrollo: desaf\xEDos y retos para la universidad en Am\xE9rica Latina y el Caribe"
     year: Unknown Year
   qc6CJjYAAAAJ:qjMakFHDy7sC:
-    citations: 3363
+    citations: 3371
     title: On the electrodynamics of moving bodies
     year: '1905'
   qc6CJjYAAAAJ:qsWQJNntlusC:
-    citations: 3227
+    citations: 3228
     title: Ideas and opinions
     year: '1995'
   qc6CJjYAAAAJ:quBVm8e4N6QC:
@@ -3602,11 +3602,11 @@ papers:
     title: "Zu Kaluzas Theorie des Zusammenhanges von Gravitation und Elektrizit\xE4t. Zweite Mitteilung"
     year: '2006'
   qc6CJjYAAAAJ:qxL8FJ1GzNcC:
-    citations: 616
+    citations: 615
     title: Geometrie und erfahrung
     year: '1921'
   qc6CJjYAAAAJ:qyhmnyLat1gC:
-    citations: 27962
+    citations: 27983
     title: Can quantum-mechanical description of physical reality be considered complete?
     year: '1935'
   qc6CJjYAAAAJ:qzuIxkxWBNsC:
@@ -3650,7 +3650,7 @@ papers:
     title: "Gelegentliches: Zum f\xFCnfzigsten Geburtstag 14. M\xE4rz 1929 dargebracht von der Soncino-Gesellschaft der Freunde des J\xFCdischen Buches zu Berlin"
     year: '1929'
   qc6CJjYAAAAJ:rPbfW60zdgkC:
-    citations: 1207
+    citations: 1208
     title: Physics and reality
     year: '1936'
   qc6CJjYAAAAJ:rQcm2j6_ZE8C:
@@ -3662,7 +3662,7 @@ papers:
     title: A new analysis of molecule dimensions
     year: '1968'
   qc6CJjYAAAAJ:rWqKpwLRvsIC:
-    citations: 3140
+    citations: 3147
     title: Die feldgleichungen der gravitation
     year: Unknown Year
   qc6CJjYAAAAJ:rbgNTKsR3fAC:
@@ -3722,7 +3722,7 @@ papers:
     title: "La th\xE9orie corpusculaire des rayons X et la structure des cristaux."
     year: Unknown Year
   qc6CJjYAAAAJ:sAujV351FBYC:
-    citations: 4885
+    citations: 4889
     title: The meaning of relativity
     year: '1950'
   qc6CJjYAAAAJ:sIDMtVbdO0QC:
@@ -3734,7 +3734,7 @@ papers:
     title: Mis ideas y opiniones
     year: '2011'
   qc6CJjYAAAAJ:sNmaIFBj_lkC:
-    citations: 6
+    citations: 8
     title: Compton Effect
     year: '1966'
   qc6CJjYAAAAJ:sYWh8IhQ1GMC:
@@ -3754,7 +3754,7 @@ papers:
     title: The laws of science and the laws of ethics
     year: '1950'
   qc6CJjYAAAAJ:sgsej9ZJWHMC:
-    citations: 4460
+    citations: 4469
     title: "N\xE4herungsweise Integration der Feldgleichungen der Gravitation"
     year: '1916'
   qc6CJjYAAAAJ:siTy-4AL0AwC:
@@ -3866,7 +3866,7 @@ papers:
     title: "Bemerkung zu meiner Arbeit \u201CZur allgemeinen Relativit\xE4tstheorie\u201D"
     year: '2006'
   qc6CJjYAAAAJ:ufrVoPGSRksC:
-    citations: 647
+    citations: 646
     title: The influence of the expansion of space on the gravitation fields surrounding the individual stars
     year: '1945'
   qc6CJjYAAAAJ:uh8FjILnQOkC:
@@ -3930,7 +3930,7 @@ papers:
     title: On the five-dimensional representation of gravitation and electricity
     year: '1941'
   qc6CJjYAAAAJ:viPVbuMW504C:
-    citations: 404
+    citations: 403
     title: Collected Scientific Works
     year: '1965'
   qc6CJjYAAAAJ:viTTOddtVMkC:
@@ -3970,11 +3970,11 @@ papers:
     title: "Introduction aux th\xE8ories de M. Einstein en vue de leur application a l'astronomie"
     year: '1921'
   qc6CJjYAAAAJ:vytXtR8tOLIC:
-    citations: 3357
+    citations: 3366
     title: B. preuss
     year: '1916'
   qc6CJjYAAAAJ:vzY-6mMDyDUC:
-    citations: 87
+    citations: 88
     title: 'The Berlin Years, Correspondence 1914-1918: English Translation'
     year: '1998'
   qc6CJjYAAAAJ:w1G5vK4DiEkC:
@@ -4018,7 +4018,7 @@ papers:
     title: "La teoria della relativit\xE0"
     year: '1987'
   qc6CJjYAAAAJ:wgKq3sYidysC:
-    citations: 533
+    citations: 532
     title: Concerning an heuristic point of view toward the emission and transformation of light
     year: '1965'
   qc6CJjYAAAAJ:wkm4DBaukwsC:
@@ -4058,7 +4058,7 @@ papers:
     title: "Briefe zur Wellenmechanik [von][Erwin] Schr\xF6dinger,[Max] Planck,[ALbert] Einstein und [Hendrik Antoon] Lorentz"
     year: '1963'
   qc6CJjYAAAAJ:xvKSgulxyWUC:
-    citations: 797
+    citations: 795
     title: 'The collected papers of Albert Einstein: writings, 1912-1914. The Swiss years'
     year: '1966'
   qc6CJjYAAAAJ:xwIxJehhd2UC:
@@ -4078,7 +4078,7 @@ papers:
     title: 'Albert Einstein] to Gustav Mie: Letter, 29 Dec 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:yIeBiWEAh44C:
-    citations: 1351
+    citations: 1352
     title: "\xDCber den Einflu\xDF der Schwerkraft auf die Ausbreitung des Lichtes"
     year: '2006'
   qc6CJjYAAAAJ:yJjnfzR0HrkC:


### PR DESCRIPTION
## Summary
- Syncs this fork with `alshedivat/al-folio@f6990ef2`.
- Pulls upstream commits for Google Scholar citation cache refreshes and the README user-community link update.
- Keeps local site citation data instead of upstream sample citation data.

## Upstream commits included
- `1ecfde5a` Add a link to my lab website in user community section (#3645)
- `8e1ecd2f` Update Google Scholar citations
- `2b5eacac` Update Google Scholar citations
- `f6990ef2` Update Google Scholar citations

## Conflict resolution
| File | Resolution strategy |
| --- | --- |
| `_data/citations.yml` | Kept local site citation cache; upstream contained sample/default Google Scholar citation data. |

## Verification
- `docker compose up --build -d`
- Waited for Jekyll `Server running` log
- HTTP checks: `/`, `/publications/`, `/cv/` all returned 200
- Browser checks: home page loads, nav links visible, publications page renders bibliography, CV page renders, dark mode toggle changes state, no console errors

## Merge reminder
Please use a regular merge, not squash merge, so upstream al-folio history is preserved for future syncs.