### PR TITLE
Add EPFL talk subtitle

### DIFF
--- a/_data/outreach.yml
+++ b/_data/outreach.yml
@@ -1,6 +1,6 @@
 talks:
   - date: "2026-07-10"
-    title: "Graph Machine Learning for Dynamic Financial Networks"
+    title: "Graph Machine Learning for Dynamic Financial Networks: From Foundations to the Lightning Network"
     venue: "Swissquote Workshop on Graph Learning in Financial Networks, EPFL"
     venue_url: https://www.epfl.ch/schools/cdm/college-of-management-of-technology/research/swiss-finance-institute/events/other-events/workshop-on-graph-learning-in-financial-networks/
     slides_html_url: /assets/presentations/graph_machine_learning_dynamic_financial_networks_epfl_2026_07_10.html


### PR DESCRIPTION
## What changed

This adds the presentation subtitle to the EPFL talk title on the Outreach page.

The full title fits on one line in the desktop layout without overflow.

## Checks

`npm run lint:prettier` passed.

The Docker preview returned the updated Outreach page. The browser layout check found no overflow.
