### PR TITLE
Add awards and research funding to outreach page

### DIFF
--- a/.al-folio-overrides.yml
+++ b/.al-folio-overrides.yml
@@ -27,8 +27,8 @@ overrides:
     gem_version: 1.0.11
     upstream_path: _layouts/bib.liquid
     upstream_sha256: 430311d9b94adf6fb1c2fab7609f6e726efc98e2b50e7b1c4cde0ad654c04506
-    local_sha256: e2464ecf6a9e32235489baa008882d6595803bca9b8be21875701c91047c382d
-    acknowledged_at: "2026-06-05"
+    local_sha256: 19081c88d9b88bf62797c8982a8fef53c6d505eba72971c8786ea7fa720ac8ed
+    acknowledged_at: "2026-07-21"
   assets/css/main.scss:
     owner: al_folio_core
     gem_version: 1.0.11

--- a/_data/outreach.yml
+++ b/_data/outreach.yml
@@ -161,6 +161,52 @@ workshops:
     venue: "AAAI 2021"
     role: "PC Member"
 
+awards:
+  - date: "2017-01-01"
+    title: "Olav Beckmann Project Prize"
+    institution: "Imperial College London"
+    description: "For outstanding second-year project work."
+
+  - date: "2017-01-01"
+    years: "2016, 2017"
+    title: "Engineering Dean's List"
+    institution: "Imperial College London"
+    description: "Top 10% of cohort. Received in two consecutive years."
+
+  - date: "2016-01-01"
+    title: "G-Research Prize (Gloucester Research Ltd Prize at the time of award)"
+    institution: "Imperial College London"
+    description: "Awarded annually to up to 10 non-final-year Computer Science students for academic excellence."
+
+  - date: "2015-05-22"
+    title: "President's Undergraduate Scholarship"
+    institution: "Imperial College London"
+    description: "Imperial's most prestigious undergraduate award, recognizing academic excellence and potential. Funding: £3,000."
+
+research_grants:
+  - date: "2026-07-02"
+    title: "ISCRA-C Research Computing Grant"
+    institution: "CINECA"
+    project: "DOLPH-ID: Dolphin Emitter Identification from Whistle Acoustics"
+    description: "Allocation of 8,500 GPU-hours on Leonardo's NVIDIA A100 64 GB accelerators."
+    value: "≈€20,000"
+    value_qualifier: "equivalent"
+    duration: "9 months"
+
+  - date: "2026-04-01"
+    title: "Research Fellowship"
+    institution: "Sapienza University of Rome"
+    description: "For postdoctoral research on machine learning for non-human communication."
+    value: "€36,000"
+    duration: "12 months"
+
+  - date: "2023-02-06"
+    years: "2022, 2023"
+    title: "Google Cloud Research Credits"
+    institution: "Google"
+    description: "GCP credits for PhD research. Received in two consecutive years."
+    value: "$1,000/year"
+
 mentoring:
   - start_date: "2025-05-01"
     name: "Davide Marincione"

--- a/_includes/outreach/awards.liquid
+++ b/_includes/outreach/awards.liquid
@@ -1,0 +1,25 @@
+<div class="table-responsive">
+  <table class="table table-sm table-borderless">
+    <tbody>
+      {% assign awards = site.data.outreach.awards | sort: 'date' | reverse %}
+      {% for item in awards %}
+        <tr>
+          <td class="text-nowrap" style="width: 5rem">
+            <small class="text-muted">
+              {%- if item.years -%}
+                {{ item.years }}
+              {%- else -%}
+                {{ item.date | date: '%Y' }}
+              {%- endif -%}
+            </small>
+          </td>
+          <td>
+            <strong>{{ item.title }}</strong>
+            <span class="text-muted">— {{ item.institution }}</span><br>
+            <small>{{ item.description }}</small>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/_includes/outreach/research_grants.liquid
+++ b/_includes/outreach/research_grants.liquid
@@ -1,0 +1,52 @@
+<div class="table-responsive">
+  <table class="table table-sm table-borderless research-grants-table">
+    <tbody>
+      {% assign research_grants = site.data.outreach.research_grants | sort: 'date' | reverse %}
+      {% for item in research_grants %}
+        <tr>
+          <td class="text-nowrap" style="width: 5rem">
+            <small class="text-muted">
+              {%- if item.years -%}
+                {{ item.years }}
+              {%- else -%}
+                {{ item.date | date: '%Y' }}
+              {%- endif -%}
+            </small>
+          </td>
+          <td>
+            <strong>{{ item.title }}</strong>
+            <span class="text-muted">— {{ item.institution }}</span><br>
+            {% if item.project %}
+              <small
+                ><em>{{ item.project }}</em></small
+              ><br>
+            {% endif %}
+            {% if item.description %}
+              <small>{{ item.description }}</small>
+            {% endif %}
+            <span class="research-grant-meta-mobile">
+              <span class="research-grant-value">{{ item.value }}</span>
+              {% if item.value_qualifier %}
+                <small class="text-muted">{{ item.value_qualifier }}</small>
+              {% endif %}
+              {% if item.duration %}
+                <br>
+                <small class="text-muted">{{ item.duration }}</small>
+              {% endif %}
+            </span>
+          </td>
+          <td class="research-grant-meta">
+            <span class="research-grant-value">{{ item.value }}</span>
+            {% if item.value_qualifier %}
+              <small class="text-muted">{{ item.value_qualifier }}</small>
+            {% endif %}
+            {% if item.duration %}
+              <br>
+              <small class="text-muted">{{ item.duration }}</small>
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/_includes/outreach/research_grants.liquid
+++ b/_includes/outreach/research_grants.liquid
@@ -14,36 +14,30 @@
             </small>
           </td>
           <td>
-            <strong>{{ item.title }}</strong>
-            <span class="text-muted">— {{ item.institution }}</span><br>
-            {% if item.project %}
-              <small
-                ><em>{{ item.project }}</em></small
-              ><br>
-            {% endif %}
-            {% if item.description %}
-              <small>{{ item.description }}</small>
-            {% endif %}
-            <span class="research-grant-meta-mobile">
-              <span class="research-grant-value">{{ item.value }}</span>
-              {% if item.value_qualifier %}
-                <small class="text-muted">{{ item.value_qualifier }}</small>
-              {% endif %}
-              {% if item.duration %}
-                <br>
-                <small class="text-muted">{{ item.duration }}</small>
-              {% endif %}
-            </span>
-          </td>
-          <td class="research-grant-meta">
-            <span class="research-grant-value">{{ item.value }}</span>
-            {% if item.value_qualifier %}
-              <small class="text-muted">{{ item.value_qualifier }}</small>
-            {% endif %}
-            {% if item.duration %}
-              <br>
-              <small class="text-muted">{{ item.duration }}</small>
-            {% endif %}
+            <div class="research-grant-content">
+              <div>
+                <strong>{{ item.title }}</strong>
+                <span class="text-muted">— {{ item.institution }}</span><br>
+                {% if item.project %}
+                  <small
+                    ><em>{{ item.project }}</em></small
+                  ><br>
+                {% endif %}
+                {% if item.description %}
+                  <small>{{ item.description }}</small>
+                {% endif %}
+              </div>
+              <div class="research-grant-meta">
+                <span>{{ item.value }}</span>
+                {% if item.value_qualifier %}
+                  <small class="text-muted">{{ item.value_qualifier }}</small>
+                {% endif %}
+                {% if item.duration %}
+                  <br>
+                  <small class="text-muted">{{ item.duration }}</small>
+                {% endif %}
+              </div>
+            </div>
           </td>
         </tr>
       {% endfor %}

--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -488,7 +488,7 @@
       <div class="bibtex hidden">
         {% highlight bibtex %}
         {{- entry.bibtex | hideCustomBibtex -}}
-        {% endhighlight %}
+      {% endhighlight %}
       </div>
     {% endif %}
 

--- a/_pages/outreach.md
+++ b/_pages/outreach.md
@@ -2,7 +2,7 @@
 layout: page
 title: Outreach
 permalink: /outreach/
-description: Talks, panels, community work, and research mentoring.
+description: Talks, panels, community work, research mentoring, grants, and awards.
 nav: true
 nav_order: 4
 ---

--- a/_pages/outreach.md
+++ b/_pages/outreach.md
@@ -28,3 +28,11 @@ Mentoring bright and motivated students is one of the most rewarding aspects of 
 Below are the students I have had the pleasure to supervise. If you are a **prospective student interested in working with me**, feel free to contact my former mentees to learn more about my mentoring style and what collaboration with me looks like.
 
 {% include outreach/mentoring.liquid %}
+
+## Awards
+
+{% include outreach/awards.liquid %}
+
+## Research Grants & Fellowships
+
+{% include outreach/research_grants.liquid %}

--- a/_pages/outreach.md
+++ b/_pages/outreach.md
@@ -29,10 +29,10 @@ Below are the students I have had the pleasure to supervise. If you are a **pros
 
 {% include outreach/mentoring.liquid %}
 
-## Awards
-
-{% include outreach/awards.liquid %}
-
 ## Research Grants & Fellowships
 
 {% include outreach/research_grants.liquid %}
+
+## Awards
+
+{% include outreach/awards.liquid %}

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -236,31 +236,26 @@ html[data-theme="dark"] {
   text-transform: uppercase;
 }
 
-.research-grants-table {
+.research-grant-content {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+
   .research-grant-meta {
-    width: 9rem;
+    min-width: 9rem;
     text-align: right;
     white-space: nowrap;
-  }
-
-  .research-grant-value {
-    font-weight: 400;
-  }
-
-  .research-grant-meta-mobile {
-    display: none;
-    margin-top: 0.2rem;
   }
 }
 
 @media (max-width: 575.98px) {
-  .research-grants-table {
-    .research-grant-meta {
-      display: none;
-    }
+  .research-grant-content {
+    grid-template-columns: 1fr;
+    gap: 0.2rem;
 
-    .research-grant-meta-mobile {
-      display: block;
+    .research-grant-meta {
+      min-width: 0;
+      text-align: left;
     }
   }
 }

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -235,3 +235,32 @@ html[data-theme="dark"] {
 .links a.btn {
   text-transform: uppercase;
 }
+
+.research-grants-table {
+  .research-grant-meta {
+    width: 9rem;
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  .research-grant-value {
+    font-weight: 400;
+  }
+
+  .research-grant-meta-mobile {
+    display: none;
+    margin-top: 0.2rem;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .research-grants-table {
+    .research-grant-meta {
+      display: none;
+    }
+
+    .research-grant-meta-mobile {
+      display: block;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add an Awards section with Imperial College honours
- add a Research Grants & Fellowships section covering Google Cloud credits, the Sapienza postdoctoral fellowship, and the CINECA ISCRA-C allocation
- present institutions compactly beside titles and funding/value metadata in a responsive right-hand column
- include the DOLPH-ID project title and concise research context

## Impact

The outreach page now presents academic recognition and research support in a compact, scannable format. Funding metadata remains right-aligned on larger screens and moves below each entry on mobile.

## Validation

- `npm run lint:prettier`
- targeted Prettier check for all changed files
- `git diff --check`
- rendered `/outreach/` content verification
- desktop and mobile visual review